### PR TITLE
Fixed main: simplemde.js -> easymde.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "javascript",
         "fontawesome"
     ],
-    "main": "./src/js/simplemde.js",
+    "main": "./src/js/easymde.js",
     "license": "MIT",
     "author": "Jeroen Akkerman",
     "bugs": {


### PR DESCRIPTION
Looks like the file itself was renamed but the package.json wasn't updated accordingly.

Please fix, as the current releasy is broken imo.