### PR TITLE
Add searchcursor plugin

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -8,6 +8,7 @@ require('codemirror/mode/markdown/markdown.js');
 require('codemirror/addon/mode/overlay.js');
 require('codemirror/addon/display/placeholder.js');
 require('codemirror/addon/selection/mark-selection.js');
+require('codemirror/addon/search/searchcursor.js');
 require('codemirror/mode/gfm/gfm.js');
 require('codemirror/mode/xml/xml.js');
 var CodeMirrorSpellChecker = require('codemirror-spell-checker');


### PR DESCRIPTION
I need to highlight text programmatically, so I added the searchcursor plugin.

Why do I need this? I have a media library alongside the markdown editor. When a user tries to remove an image that's still referenced (via `![...](...)`) in the markdown, I want to highlight the first occurrence.

My code looks like this:

    const body = easyMde.value();
    if (body.includes(item.url)) {
      const editor = easyMde.codemirror;
      const cursor = editor.getSearchCursor(item.url);
      cursor.findNext();
      editor.setSelection(cursor.pos.from, cursor.pos.to);
      EventBus.error(`Please remove from text first.`);
      return;
    }

Honestly, I am not sure this is the right approach. Maybe I should add the plugin in my "user code", but I don't know if that's possible.