### PR TITLE
Add optional onToggleFullScreen support from options

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -259,6 +259,9 @@ function toggleFullScreen(editor) {
     var sidebyside = cm.getWrapperElement().nextSibling;
     if (/editor-preview-active-side/.test(sidebyside.className))
         toggleSideBySide(editor);
+
+	if(editor.options.onToggleFullScreen)
+		editor.options.onToggleFullScreen(cm.getOption("fullScreen") || false);
 }
 
 


### PR DESCRIPTION
I have a project that wraps your editor in a React component, and I needed a way to append a class to a wrapper component. This change allowed me to set my component's state, thereby giving me the opportunity to conditionally style it.
Here is how I use your library, as well as the proposed change:
```javascript
import EasyMDE from "easymde/src/js/easymde";

//In the component class
componentDidMount() {
    this.mde = new EasyMDE({
        onToggleFullScreen: this.onToggleFullscreen,
        //...the rest of the properties I pass in
    });
    //... the rest of my code here uses the "blur" and "change" events of this.mde.codemirror to bridge the React gap
}

//A single parameter is passed in, which is the current fullscreen state of the editor
onToggleFullscreen = (fullscreen) => {
    this.setState({ fullscreen });
}
```

This change works with both the side-by-side mode, and the fullscreen mode, as well as any call to `EasyMDE.toggleFullScreen` or `EasyMDE.prototype.toggleFullScreen` that other developers might use. I've thoroughly tested it with my project, and so far I've been unable to break it unless someone enters a non-function truthy value for `onToggleFullScreen`.

I'm not sure how to create a JSFiddle for this specific project, but since it's a small change I'm not sure if it's entirely warranted. Finally, I'd be happy to add the necessary documentation for this, but I'm not sure if I should add a section to the EasyMDE part of the README, or append it to the SimpleMDE part that has the rest of the props.