### PR TITLE
Readme rework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Hey, welcome to the party! 🎉
 
-Thank you so much to contribute to EasyMDE. 😘
+Thank you so much for contributing to EasyMDE. 😘
 
 
 ## Asking questions, suggesting wonderful ideas or reporting bugs
@@ -12,7 +12,7 @@ You can [submit an issue️](https://github.com/Ionaru/easy-markdown-editor/issu
 
 ## Coding
 
-### 📦 Prerequies
+### 📦 Prerequisites
 
 You need node.js and npm.
 
@@ -39,13 +39,7 @@ git clone https://github.com/Ionaru/easy-markdown-editor.git
 Then install the EasyMDE for development environment with npm:
 
 ```bash
-npm install --save-dev
-```
-
-And check that everything is ok by running Gulp:
-
-```bash
-gulp
+npm install
 ```
 
 Yay! You are ready! 🍾

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Yay! You are ready! 🍾
 
 1. First, [create a fork of this project](https://github.com/Ionaru/easy-markdown-editor/fork), and copy the https URL (*clone or download* button) of your project (something like https://github.com/YOUR_USERNAME/easy-markdown-editor.git );
 2. a) If you already cloned and worked on the project: `git remote add source https://github.com/Ionaru/easy-markdown-editor.git`;
-   b) otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
+b) otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
 3. create a new dedicated branch `git checkout -b myMergeRequest`;
 4. write some nice code and commit your work;
 5. check files against the ESLint syntax and build minified versions: `gulp`;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ You need node.js and npm.
 To install them on Debian-based systems:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 echo -e "nodejs version:\t$(nodejs -v) \nnpm version:\t$(npm -v)"
 # check that you have node.js and npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,8 @@ Yay! You are ready! 🍾
 ### ⤴️ Creating a pull request
 
 1. First, [create a fork of this project](https://github.com/Ionaru/easy-markdown-editor/fork), and copy the https URL (*clone or download* button) of your project (something like https://github.com/YOUR_USERNAME/easy-markdown-editor.git );
-2.
-- a) If you already cloned and worked on the project: `git remote add source https://github.com/Ionaru/easy-markdown-editor.git`;
-- b) otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
+2. a) If you already cloned and worked on the project: `git remote add source https://github.com/Ionaru/easy-markdown-editor.git`;
+   b) otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
 3. create a new dedicated branch `git checkout -b myMergeRequest`;
 4. write some nice code and commit your work;
 5. check files against the ESLint syntax and build minified versions: `gulp`;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,14 +52,15 @@ Yay! You are ready! 🍾
 
 ### ⤴️ Creating a pull request
 
-- 1. First, [create a fork of this project](https://github.com/Ionaru/easy-markdown-editor/fork), and copy the https URL (*clone or download* button) of your project (something like https://github.com/YOUR_USERNAME/easy-markdown-editor.git );
-- 2.a If you already cloned and worked on the project: `git remote add source https://github.com/Ionaru/easy-markdown-editor.git`;
-- 2.b otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
-- 3. create a new dedicated branch `git checkout -b myMergeRequest`;
-- 4. write some nice code and commit your work;
-- 5. check files against the ESLint syntax and build minified versions: `gulp`;
-- 6. push it to a dedicated branch `git push origin myMergeRequest`;
-- 7. got to the [main project page](https://github.com/Ionaru/easy-markdown-editor) and click on the button *Compare and pull request*, then fill the description.
+1. First, [create a fork of this project](https://github.com/Ionaru/easy-markdown-editor/fork), and copy the https URL (*clone or download* button) of your project (something like https://github.com/YOUR_USERNAME/easy-markdown-editor.git );
+2.
+- a) If you already cloned and worked on the project: `git remote add source https://github.com/Ionaru/easy-markdown-editor.git`;
+- b) otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
+3. create a new dedicated branch `git checkout -b myMergeRequest`;
+4. write some nice code and commit your work;
+5. check files against the ESLint syntax and build minified versions: `gulp`;
+6. push it to a dedicated branch `git push origin myMergeRequest`;
+7. got to the [main project page](https://github.com/Ionaru/easy-markdown-editor) and click on the button *Compare and pull request*, then fill the description.
 
 If you want to make other pull requests, go back to the development branch (`git checkout development`), update it (`git pull --rebase source development`), then follow the instructions above from step 3.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Hey, welcome to the party! 🎉
+
+Thank you so much to contribute to EasyMDE. 😘
+
+
+## Asking questions, suggesting wonderful ideas or reporting bugs
+
+You can [submit an issue️](https://github.com/Ionaru/easy-markdown-editor/issues/new) on this GitHub repository.
+
+
+## Coding
+
+### 📦 Prerequies
+
+You need node.js and npm.
+
+To install them on Debian-based systems:
+
+```bash
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+sudo apt-get install -y nodejs
+echo -e "nodejs version:\t$(nodejs -v) \nnpm version:\t$(npm -v)"
+# check that you have node.js and npm.
+```
+
+For other systems, please [read the official page](https://nodejs.org/en/download/).
+
+
+### 🏗️ Installation
+
+Here we go! 🤠 First, clone this repository:
+
+```bash
+git clone https://github.com/Ionaru/easy-markdown-editor.git
+```
+
+Then install the EasyMDE for development environment with npm:
+
+```bash
+npm install --save-dev
+```
+
+And check that everything is ok by running Gulp:
+
+```bash
+gulp
+```
+
+Yay! You are ready! 🍾
+
+### ⤴️ Creating a pull request
+
+- 1. First, [create a fork of this project](https://github.com/Ionaru/easy-markdown-editor/fork), and copy the https URL (*clone or download* button) of your project (something like https://github.com/YOUR_USERNAME/easy-markdown-editor.git );
+- 2.a If you already cloned and worked on the project: `git remote add source https://github.com/Ionaru/easy-markdown-editor.git`;
+- 2.b otherwise, clone your fork: `git clone https://github.com/YOUR_USERNAME/easy-markdown-editor.git`;
+- 3. create a new dedicated branch `git checkout -b myMergeRequest`;
+- 4. write some nice code and commit your work;
+- 5. check files against the ESLint syntax and build minified versions: `gulp`;
+- 6. push it to a dedicated branch `git push origin myMergeRequest`;
+- 7. got to the [main project page](https://github.com/Ionaru/easy-markdown-editor) and click on the button *Compare and pull request*, then fill the description.
+
+If you want to make other pull requests, go back to the development branch (`git checkout development`), update it (`git pull --rebase source development`), then follow the instructions above from step 3.
+
+Thank you! 💜

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,17 @@ Here we go! 🤠 First, clone this repository:
 
 ```bash
 git clone https://github.com/Ionaru/easy-markdown-editor.git
+cd easy-markdown-editor
 ```
 
-Then install the EasyMDE for development environment with npm:
+Then install the EasyMDE with npm:
 
 ```bash
 npm install
 ```
 
 Yay! You are ready! 🍾
+
 
 ### ⤴️ Creating a pull request
 
@@ -56,6 +58,6 @@ Yay! You are ready! 🍾
 6. push it to a dedicated branch `git push origin myMergeRequest`;
 7. got to the [main project page](https://github.com/Ionaru/easy-markdown-editor) and click on the button *Compare and pull request*, then fill the description.
 
-If you want to make other pull requests, go back to the development branch (`git checkout development`), update it (`git pull --rebase source development`), then follow the instructions above from step 3.
+If you want to make other pull requests, go back to the master branch (`git checkout master`), update it (`git pull --rebase source master`), then follow the instructions above from step 3.
 
 Thank you! 💜

--- a/README.md
+++ b/README.md
@@ -356,3 +356,10 @@ Changes include:
 * Typescript support
 
 My intention is to continue development on this project, improving it and keeping it alive.
+
+## License
+
+This project is released under the [MIT License](./LICENSE).
+
+- Copyright (c) 2015 Sparksuite, Inc.
+- Copyright (c) 2017 Jeroen Akkerman.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,15 @@
 [SimpleMDE, made by Sparksuite](https://github.com/sparksuite/simplemde-markdown-editor/).
 Go to the [dedicated section](#simplemde-fork) for more information.
 
-This repository is a fork of [SimpleMDE, made by Sparksuite](https://github.com/sparksuite/simplemde-markdown-editor/).
-
-A drop-in JavaScript textarea replacement for writing beautiful and understandable Markdown.
+A drop-in JavaScript text area replacement for writing beautiful and understandable Markdown.
 EasyMDE allows users who may be less experienced with Markdown to use familiar toolbar buttons and shortcuts.
+
 In addition, the syntax is rendered while editing to clearly show the expected result. Headings are larger, emphasized words are italicized, links are underlined, etc.
 
-EasyMDE also features both built-in autosaving and spell checking.
+EasyMDE also features both built-in auto saving and spell checking.
 The editor is entirely customizable, from theming to toolbar buttons and javascript hooks.
 
-[**Demo**](https://easymde.tk/)
+[**Try the demo**](https://easymde.tk/)
 
 [![Preview](https://user-images.githubusercontent.com/3472373/51319377-26fe6e00-1a5d-11e9-8cc6-3137a566796d.png)](https://easymde.tk/)
 
@@ -36,7 +35,7 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
   - [Keyboard shortcuts](#keyboard-shortcuts)
 - [Advanced use](#advanced-use)
   - [Event handling](#event-handling)
-  - [Removing EasyMDE from textarea](#removing-easymde-from-textarea)
+  - [Removing EasyMDE from text area](#removing-easymde-from-text-area)
   - [Useful methods](#useful-methods)
 - [How it works](#how-it-works)
 - [SimpleMDE fork](#simplemde-fork)
@@ -45,12 +44,14 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
 
 ## Install EasyMDE
 
-Via [npm](https://www.npmjs.com/package/easymde).
+Via [npm](https://www.npmjs.com/package/easymde):
+
 ```
 npm install easymde --save
 ```
 
-Via the UNPKG CDN.
+Via the *UNPKG* CDN:
+
 ```html
 <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
 <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
@@ -61,7 +62,8 @@ Via the UNPKG CDN.
 
 ### Loading the editor
 
-After installing and/or importing the module, you can load EasyMDE onto the first TextArea on the webpage.
+After installing and/or importing the module, you can load EasyMDE onto the first TextArea on the web page:
+
 ```html
 <textarea></textarea>
 <script>
@@ -69,7 +71,8 @@ var easyMDE = new EasyMDE();
 </script>
 ```
 
-Alternatively you can select a specific TextArea, via Javascript.
+Alternatively you can select a specific TextArea, via Javascript:
+
 ```html
 <textarea id="my-text-area"></textarea>
 <script>
@@ -77,7 +80,8 @@ var easyMDE = new EasyMDE({element: document.getElementById('my-text-area')});
 </script>
 ```
 
-Or via jQuery.
+Or via jQuery:
+
 ```html
 <textarea id="my-text-area"></textarea>
 <script>
@@ -88,14 +92,16 @@ var easyMDE = new EasyMDE({element: $('#my-text-area')[0]});
 
 ### Editor functions
 
-Use EasyMDE.value() to get the content of the editor.
+Use EasyMDE.value() to get the content of the editor:
+
 ```html
 <script>
 easyMDE.value();
 </script>
 ```
 
-Use EasyMDE.value(val) to set the content of the editor.
+Use EasyMDE.value(val) to set the content of the editor:
+
 ```html
 <script>
 easyMDE.value('New input for **EasyMDE**');
@@ -108,17 +114,17 @@ easyMDE.value('New input for **EasyMDE**');
 ### Options list
 
 - **autoDownloadFontAwesome**: If set to `true`, force downloads Font Awesome (used for icons). If set to `false`, prevents downloading. Defaults to `undefined`, which will intelligently check whether Font Awesome has already been included, then download accordingly.
-- **autofocus**: If set to `true`, autofocuses the editor. Defaults to `false`.
+- **autofocus**: If set to `true`, focuses the editor automatically. Defaults to `false`.
 - **autosave**: *Saves the text that's being written and will load it back in the future. It will forget the text when the form it's contained in is submitted.*
-  - **enabled**: If set to `true`, autosave the text. Defaults to `false`.
+  - **enabled**: If set to `true`, saves the text automatically. Defaults to `false`.
   - **delay**: Delay between saves, in milliseconds. Defaults to `10000` (10s).
   - **uniqueId**: You must set a unique string identifier so that EasyMDE can autosave. Something that separates this from other instances of EasyMDE elsewhere on your website.
 - **blockStyles**: Customize how certain buttons that style blocks of text behave.
   - **bold**: Can be set to `**` or `__`. Defaults to `**`.
   - **code**: Can be set to  ```` ``` ```` or `~~~`.  Defaults to ```` ``` ````.
   - **italic**: Can be set to `*` or `_`. Defaults to `*`.
-- **element**: The DOM element for the textarea to use. Defaults to the first textarea on the page.
-- **forceSync**: If set to `true`, force text changes made in EasyMDE to be immediately stored in original textarea. Defaults to `false`.
+- **element**: The DOM element for the text area to use. Defaults to the first text area on the page.
+- **forceSync**: If set to `true`, force text changes made in EasyMDE to be immediately stored in original text area. Defaults to `false`.
 - **hideIcons**: An array of icon names to hide. Can be used to hide specific icons shown by default without completely customizing the toolbar.
 - **indentWithTabs**: If set to `false`, indent using spaces instead of tabs. Defaults to `true`.
 - **initialValue**: If set, will customize the initial value of the editor.
@@ -128,8 +134,8 @@ easyMDE.value('New input for **EasyMDE**');
   - link
   - table
 - **lineWrapping**: If set to `false`, disable line wrapping. Defaults to `true`.
-- **minHeight**: Sets the minimum height for the composition area, before it starts auto-growing. Should be a string containing a valid CSS value like `"500px"`. Dafaults to `"300px"`.
-- **onToggleFullScreen**: A function that gets called when the editor's fullscreen mode is toggled. The function will be passed a boolean as parameter, `true` when the editor is currently going into fullscreen mode, or `false`.
+- **minHeight**: Sets the minimum height for the composition area, before it starts auto-growing. Should be a string containing a valid CSS value like `"500px"`. Defaults to `"300px"`.
+- **onToggleFullScreen**: A function that gets called when the editor's full screen mode is toggled. The function will be passed a boolean as parameter, `true` when the editor is currently going into full screen mode, or `false`.
 - **parsingConfig**: Adjust settings for parsing the Markdown during editing (not previewing).
   - **allowAtxHeaderWithoutSpace**: If set to `true`, will render headers without a space after the `#`. Defaults to `false`.
   - **strikethrough**: If set to `false`, will not process GFM strikethrough syntax. Defaults to `true`.
@@ -168,7 +174,7 @@ var editor = new EasyMDE({
 	autosave: {
 		enabled: true,
 		uniqueId: "MyUniqueID",
-		delay: 1000,
+		delay: 1000
 	},
 	blockStyles: {
 		bold: "__",
@@ -183,14 +189,14 @@ var editor = new EasyMDE({
 		horizontalRule: ["", "\n\n-----\n\n"],
 		image: ["![](http://", ")"],
 		link: ["[", "](http://)"],
-		table: ["", "\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text      | Text     |\n\n"],
+		table: ["", "\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text      | Text     |\n\n"]
 	},
 	lineWrapping: false,
 	minHeight: "500px",
 	parsingConfig: {
 		allowAtxHeaderWithoutSpace: true,
 		strikethrough: false,
-		underscoresBreakWords: true,
+		underscoresBreakWords: true
 	},
 	placeholder: "Type here...",
 	previewRender: function(plainText) {
@@ -206,11 +212,11 @@ var editor = new EasyMDE({
 	promptURLs: true,
 	promptTexts: {
 		image: "Custom prompt for URL:",
-		link: "Custom prompt for URL:",
+		link: "Custom prompt for URL:"
 	},
 	renderingConfig: {
 		singleLineBreaks: false,
-		codeSyntaxHighlighting: true,
+		codeSyntaxHighlighting: true
 	},
 	shortcuts: {
 		drawTable: "Cmd-Alt-T"
@@ -233,14 +239,14 @@ var editor = new EasyMDE({
 	syncSideBySidePreviewScroll: false,
 	tabSize: 4,
 	toolbar: false,
-	toolbarTips: false,
+	toolbarTips: false
 });
 ```
 
 
 ### Toolbar icons
 
-Below are the built-in toolbar icons (only some of which are enabled by default), which can be reorganized however you like. "Name" is the name of the icon, referenced in the JS. "Action" is either a function or a URL to open. "Class" is the class given to the icon. "Tooltip" is the small tooltip that appears via the `title=""` attribute. Note that shortcut hints are added automatically and reflect the specified action if it has a keybind assigned to it (i.e. with the value of `action` set to `bold` and that of `tooltip` set to `Bold`, the final text the user will see would be "Bold (Ctrl-B)").
+Below are the built-in toolbar icons (only some of which are enabled by default), which can be reorganized however you like. "Name" is the name of the icon, referenced in the JS. "Action" is either a function or a URL to open. "Class" is the class given to the icon. "Tooltip" is the small tooltip that appears via the `title=""` attribute. Note that shortcut hints are added automatically and reflect the specified action if it has a key bind assigned to it (i.e. with the value of `action` set to `bold` and that of `tooltip` set to `Bold`, the final text the user will see would be "Bold (Ctrl-B)").
 
 Additionally, you can add a separator between any icons by adding `"|"` to the toolbar array.
 
@@ -278,7 +284,7 @@ Only the order of existing buttons:
 
 ```JavaScript
 var easyMDE = new EasyMDE({
-	toolbar: ["bold", "italic", "heading", "|", "quote"],
+	toolbar: ["bold", "italic", "heading", "|", "quote"]
 });
 ```
 
@@ -290,7 +296,7 @@ var easyMDE = new EasyMDE({
 			name: "bold",
 			action: EasyMDE.toggleBold,
 			className: "fa fa-bold",
-			title: "Bold",
+			title: "Bold"
 		},
 		{
 			name: "custom",
@@ -298,11 +304,11 @@ var easyMDE = new EasyMDE({
 				// Add your own code
 			},
 			className: "fa fa-star",
-			title: "Custom Button",
+			title: "Custom Button"
 		},
-		"|", // Separator
-		...
-	],
+		"|" // Separator
+		// [, ...]
+	]
 });
 ```
 
@@ -359,13 +365,13 @@ easyMDE.codemirror.on("change", function(){
 ```
 
 
-### Removing EasyMDE from textarea
+### Removing EasyMDE from text area
 
-You can revert to the initial textarea by calling the `toTextArea` method. Note that this clears up the autosave (if enabled) associated with it. The textarea will retain any text from the destroyed EasyMDE instance.
+You can revert to the initial text area by calling the `toTextArea` method. Note that this clears up the autosave (if enabled) associated with it. The text area will retain any text from the destroyed EasyMDE instance.
 
 ```JavaScript
 var easyMDE = new EasyMDE();
-...
+// ...
 easyMDE.toTextArea();
 easyMDE = null;
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
   - [Useful methods](#useful-methods)
 - [How it works](#how-it-works)
 - [SimpleMDE fork](#simplemde-fork)
-- [Hacking EasyMDE](hacking-easymde)
+- [Hacking EasyMDE](#hacking-easymde)
 - [Contributing](#contributing)
 - [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
 [![Preview](https://user-images.githubusercontent.com/3472373/51319377-26fe6e00-1a5d-11e9-8cc6-3137a566796d.png)](https://easymde.tk/)
 
 
+## Quick access
+
+- [Install EasyMDE](#install-easymde)
+- [How to use](#how-to-use)
+  - [Loading the editor](#loading-the-editor)
+  - [Editor functions](#editor-functions)
+- [Configuration](#configuration)
+  - [Options list](#options-list)
+  - [Options example](#options-example)
+  - [Toolbar icons](#toolbar-icons)
+  - [Toolbar customization](#toolbar-customization)
+  - [Keyboard shortcuts](#keyboard-shortcuts)
+- [Advanced use](#advanced-use)
+  - [Event handling](#event-handling)
+  - [Removing EasyMDE from textarea](#removing-easymde-from-textarea)
+  - [Useful methods](#useful-methods)
+- [How it works](#how-it-works)
+- [SimpleMDE fork](#simplemde-fork)
+- [License](#license)
+
+
 ## Install EasyMDE
 
 Via [npm](https://www.npmjs.com/package/easymde).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # EasyMDE - Markdown Editor
 
+[![npm version](https://img.shields.io/npm/v/easymde.svg?style=for-the-badge)](https://www.npmjs.com/package/easymde)
+[![npm version](https://img.shields.io/npm/v/easymde/next.svg?style=for-the-badge)](https://www.npmjs.com/package/easymde/v/next)
+[![Build Status](https://img.shields.io/travis/Ionaru/easy-markdown-editor/development.svg?style=for-the-badge)](https://travis-ci.org/Ionaru/easy-markdown-editor)
+
 > This repository is a fork of
 [SimpleMDE, made by Sparksuite](https://github.com/sparksuite/simplemde-markdown-editor/).
 Go to the [dedicated section](#simplemde-fork) for more information.
@@ -16,10 +20,6 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
 [**Demo**](https://easymde.tk/)
 
 [![Preview](https://user-images.githubusercontent.com/3472373/51319377-26fe6e00-1a5d-11e9-8cc6-3137a566796d.png)](https://easymde.tk/)
-
-[![npm version](https://img.shields.io/npm/v/easymde.svg?style=for-the-badge)](https://www.npmjs.com/package/easymde)
-[![npm version](https://img.shields.io/npm/v/easymde/next.svg?style=for-the-badge)](https://www.npmjs.com/package/easymde/v/next)
-[![Build Status](https://img.shields.io/travis/Ionaru/easy-markdown-editor/development.svg?style=for-the-badge)](https://travis-ci.org/Ionaru/easy-markdown-editor)
 
 ## Install EasyMDE
 Via [npm](https://www.npmjs.com/package/easymde).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
 
 [![Preview](https://user-images.githubusercontent.com/3472373/51319377-26fe6e00-1a5d-11e9-8cc6-3137a566796d.png)](https://easymde.tk/)
 
+
 ## Install EasyMDE
+
 Via [npm](https://www.npmjs.com/package/easymde).
 ```
 npm install easymde --save
@@ -33,9 +35,10 @@ Via the UNPKG CDN.
 <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 ```
 
+
 ## How to use
 
-#### Loading the editor
+### Loading the editor
 
 After installing and/or importing the module, you can load EasyMDE onto the first TextArea on the webpage.
 ```html
@@ -61,7 +64,8 @@ var easyMDE = new EasyMDE({element: $('#my-text-area')[0]});
 </script>
 ```
 
-#### Editor functions
+
+### Editor functions
 
 Use EasyMDE.value() to get the content of the editor.
 ```html
@@ -77,7 +81,10 @@ easyMDE.value('New input for **EasyMDE**');
 </script>
 ```
 
+
 ## Configuration
+
+### Options list
 
 - **autoDownloadFontAwesome**: If set to `true`, force downloads Font Awesome (used for icons). If set to `false`, prevents downloading. Defaults to `undefined`, which will intelligently check whether Font Awesome has already been included, then download accordingly.
 - **autofocus**: If set to `true`, autofocuses the editor. Defaults to `false`.
@@ -129,8 +136,12 @@ easyMDE.value('New input for **EasyMDE**');
 - **toolbar**: If set to `false`, hide the toolbar. Defaults to the [array of icons](#toolbar-icons).
 - **toolbarTips**: If set to `false`, disable toolbar button tips. Defaults to `true`.
 
+
+### Options example
+
+Most options demonstrate the non-default behavior:
+
 ```JavaScript
-// Most options demonstrate the non-default behavior
 var editor = new EasyMDE({
 	autofocus: true,
 	autosave: {
@@ -205,7 +216,8 @@ var editor = new EasyMDE({
 });
 ```
 
-#### Toolbar icons
+
+### Toolbar icons
 
 Below are the built-in toolbar icons (only some of which are enabled by default), which can be reorganized however you like. "Name" is the name of the icon, referenced in the JS. "Action" is either a function or a URL to open. "Class" is the class given to the icon. "Tooltip" is the small tooltip that appears via the `title=""` attribute. Note that shortcut hints are added automatically and reflect the specified action if it has a keybind assigned to it (i.e. with the value of `action` set to `bold` and that of `tooltip` set to `Bold`, the final text the user will see would be "Bold (Ctrl-B)").
 
@@ -236,15 +248,22 @@ side-by-side | toggleSideBySide | Toggle Side by Side<br>fa fa-columns no-disabl
 fullscreen | toggleFullScreen | Toggle Fullscreen<br>fa fa-arrows-alt no-disable no-mobile
 guide | [This link](https://simplemde.com/markdown-guide) | Markdown Guide<br>fa fa-question-circle
 
-Customize the toolbar using the `toolbar` option like:
+
+### Toolbar customization
+
+Customize the toolbar using the `toolbar` option.
+
+Only the order of existing buttons:
 
 ```JavaScript
-// Customize only the order of existing buttons
 var easyMDE = new EasyMDE({
 	toolbar: ["bold", "italic", "heading", "|", "quote"],
 });
+```
 
-// Customize all information and/or add your own icons
+All information and/or add your own icons
+
+```Javascript
 var easyMDE = new EasyMDE({
 	toolbar: [{
 			name: "bold",
@@ -266,7 +285,8 @@ var easyMDE = new EasyMDE({
 });
 ```
 
-#### Keyboard shortcuts
+
+### Keyboard shortcuts
 
 EasyMDE comes with an array of predefined keyboard shortcuts, but they can be altered with a configuration option. The list of default ones is as follows:
 
@@ -303,7 +323,11 @@ Shortcuts are automatically converted between platforms. If you define a shortcu
 
 The list of actions that can be bound is the same as the list of built-in actions available for [toolbar buttons](#toolbar-icons).
 
-## Event handling
+
+## Advanced use
+
+### Event handling
+
 You can catch the following list of events: https://codemirror.net/doc/manual.html#events
 
 ```JavaScript
@@ -313,7 +337,9 @@ easyMDE.codemirror.on("change", function(){
 });
 ```
 
-## Removing EasyMDE from textarea
+
+### Removing EasyMDE from textarea
+
 You can revert to the initial textarea by calling the `toTextArea` method. Note that this clears up the autosave (if enabled) associated with it. The textarea will retain any text from the destroyed EasyMDE instance.
 
 ```JavaScript
@@ -323,7 +349,9 @@ easyMDE.toTextArea();
 easyMDE = null;
 ```
 
-## Useful methods
+
+### Useful methods
+
 The following self-explanatory methods may be of use while developing with EasyMDE.
 
 ```js
@@ -334,12 +362,15 @@ easyMDE.isFullscreenActive(); // returns boolean
 easyMDE.clearAutosavedValue(); // no returned value
 ```
 
+
 ## How it works
+
 EasyMDE is a continuation of SimpleMDE.
 
 SimpleMDE began as an improvement of [lepture's Editor project](https://github.com/lepture/editor), but has now taken on an identity of its own. It is bundled with [CodeMirror](https://github.com/codemirror/codemirror) and depends on [Font Awesome](http://fontawesome.io).
 
 CodeMirror is the backbone of the project and parses much of the Markdown syntax as it's being written. This allows us to add styles to the Markdown that's being written. Additionally, a toolbar and status bar have been added to the top and bottom, respectively. Previews are rendered by [Marked](https://github.com/chjj/marked) using GFM.
+
 
 ## SimpleMDE fork
 
@@ -356,6 +387,7 @@ Changes include:
 * Typescript support
 
 My intention is to continue development on this project, improving it and keeping it alive.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,16 @@ Changes include:
 My intention is to continue development on this project, improving it and keeping it alive.
 
 
+## Hacking EasyMDE
+
+You may want to edit this library to adapt its behavior to your needs. This can be done in some quick steps:
+
+1. Follow the [prerequisites](./CONTRIBUTING.md#prerequisites) and [installation](./CONTRIBUTING.md#installation) instructions in the contribution guide;
+2. Do your changes;
+3. Run `gulp` command, which will generate files: `dist/easymde.min.css` and `dist/easymde.min.js`;
+4. Copy-paste those files to your code base, and you are done.
+
+
 ## Contributing
 
 Want to contribute to EasyMDE? Thank you! We have a [contribution guide](./CONTRIBUTING.md) just for you!

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
   - [Useful methods](#useful-methods)
 - [How it works](#how-it-works)
 - [SimpleMDE fork](#simplemde-fork)
+- [Contributing](#contributing)
 - [License](#license)
 
 
@@ -414,6 +415,11 @@ Changes include:
 * Typescript support
 
 My intention is to continue development on this project, improving it and keeping it alive.
+
+
+## Contributing
+
+Want to contribute to EasyMDE? Thank you! We have a [contribution guide](./CONTRIBUTING.md) just for you!
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,29 +1,21 @@
 # EasyMDE - Markdown Editor
+
+> This repository is a fork of
+[SimpleMDE, made by Sparksuite](https://github.com/sparksuite/simplemde-markdown-editor/).
+Go to the [dedicated section](#simplemde-fork) for more information.
+
 This repository is a fork of [SimpleMDE, made by Sparksuite](https://github.com/sparksuite/simplemde-markdown-editor/).
 
 A drop-in JavaScript textarea replacement for writing beautiful and understandable Markdown.
 EasyMDE allows users who may be less experienced with Markdown to use familiar toolbar buttons and shortcuts.
 In addition, the syntax is rendered while editing to clearly show the expected result. Headings are larger, emphasized words are italicized, links are underlined, etc.
+
 EasyMDE also features both built-in autosaving and spell checking.
 The editor is entirely customizable, from theming to toolbar buttons and javascript hooks.
 
 [**Demo**](https://easymde.tk/)
 
 [![Preview](https://user-images.githubusercontent.com/3472373/51319377-26fe6e00-1a5d-11e9-8cc6-3137a566796d.png)](https://easymde.tk/)
-
-I originally made this fork to implement FontAwesome 5 compatibility into SimpleMDE. When that was done I submitted a [pull request](https://github.com/sparksuite/simplemde-markdown-editor/pull/666), which has not been accepted yet. This, and the project being inactive since May 2017, triggered me to make more changes and try to put new life into the project.
-
-Changes include:
-* FontAwesome 5 compatibility
-* Guide button works when editor is in preview mode
-* Links are now `https://` by default
-* Small styling changes
-* Support for Node 8 and beyond
-* Lots of refactored code
-* Links in preview will open in a new tab by default
-* Typescript support
-
-My intention is to continue development on this project, improving it and keeping it alive.
 
 [![npm version](https://img.shields.io/npm/v/easymde.svg?style=for-the-badge)](https://www.npmjs.com/package/easymde)
 [![npm version](https://img.shields.io/npm/v/easymde/next.svg?style=for-the-badge)](https://www.npmjs.com/package/easymde/v/next)
@@ -348,3 +340,19 @@ EasyMDE is a continuation of SimpleMDE.
 SimpleMDE began as an improvement of [lepture's Editor project](https://github.com/lepture/editor), but has now taken on an identity of its own. It is bundled with [CodeMirror](https://github.com/codemirror/codemirror) and depends on [Font Awesome](http://fontawesome.io).
 
 CodeMirror is the backbone of the project and parses much of the Markdown syntax as it's being written. This allows us to add styles to the Markdown that's being written. Additionally, a toolbar and status bar have been added to the top and bottom, respectively. Previews are rendered by [Marked](https://github.com/chjj/marked) using GFM.
+
+## SimpleMDE fork
+
+I originally made this fork to implement FontAwesome 5 compatibility into SimpleMDE. When that was done I submitted a [pull request](https://github.com/sparksuite/simplemde-markdown-editor/pull/666), which has not been accepted yet. This, and the project being inactive since May 2017, triggered me to make more changes and try to put new life into the project.
+
+Changes include:
+* FontAwesome 5 compatibility
+* Guide button works when editor is in preview mode
+* Links are now `https://` by default
+* Small styling changes
+* Support for Node 8 and beyond
+* Lots of refactored code
+* Links in preview will open in a new tab by default
+* Typescript support
+
+My intention is to continue development on this project, improving it and keeping it alive.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **bold**: Can be set to `**` or `__`. Defaults to `**`.
   - **code**: Can be set to  ```` ``` ```` or `~~~`.  Defaults to ```` ``` ````.
   - **italic**: Can be set to `*` or `_`. Defaults to `*`.
-- **element**: The DOM element for the text area to use. Defaults to the first text area on the page.
+- **element**: The DOM element for the TextArea to use. Defaults to the first TextArea on the page.
 - **forceSync**: If set to `true`, force text changes made in EasyMDE to be immediately stored in original text area. Defaults to `false`.
 - **hideIcons**: An array of icon names to hide. Can be used to hide specific icons shown by default without completely customizing the toolbar.
 - **indentWithTabs**: If set to `false`, indent using spaces instead of tabs. Defaults to `true`.
@@ -175,11 +175,11 @@ var editor = new EasyMDE({
 	autosave: {
 		enabled: true,
 		uniqueId: "MyUniqueID",
-		delay: 1000
+		delay: 1000,
 	},
 	blockStyles: {
 		bold: "__",
-		italic: "_"
+		italic: "_",
 	},
 	element: document.getElementById("MyID"),
 	forceSync: true,
@@ -190,14 +190,14 @@ var editor = new EasyMDE({
 		horizontalRule: ["", "\n\n-----\n\n"],
 		image: ["![](http://", ")"],
 		link: ["[", "](http://)"],
-		table: ["", "\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text      | Text     |\n\n"]
+		table: ["", "\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text      | Text     |\n\n"],
 	},
 	lineWrapping: false,
 	minHeight: "500px",
 	parsingConfig: {
 		allowAtxHeaderWithoutSpace: true,
 		strikethrough: false,
-		underscoresBreakWords: true
+		underscoresBreakWords: true,
 	},
 	placeholder: "Type here...",
 	previewRender: function(plainText) {
@@ -213,11 +213,11 @@ var editor = new EasyMDE({
 	promptURLs: true,
 	promptTexts: {
 		image: "Custom prompt for URL:",
-		link: "Custom prompt for URL:"
+		link: "Custom prompt for URL:",
 	},
 	renderingConfig: {
 		singleLineBreaks: false,
-		codeSyntaxHighlighting: true
+		codeSyntaxHighlighting: true,
 	},
 	shortcuts: {
 		drawTable: "Cmd-Alt-T"
@@ -234,13 +234,13 @@ var editor = new EasyMDE({
 		},
 		onUpdate: function(el) {
 			el.innerHTML = ++this.keystrokes + " Keystrokes";
-		}
+		},
 	}], // Another optional usage, with a custom status bar item that counts keystrokes
 	styleSelectedText: false,
 	syncSideBySidePreviewScroll: false,
 	tabSize: 4,
 	toolbar: false,
-	toolbarTips: false
+	toolbarTips: false,
 });
 ```
 
@@ -297,7 +297,7 @@ var easyMDE = new EasyMDE({
 			name: "bold",
 			action: EasyMDE.toggleBold,
 			className: "fa fa-bold",
-			title: "Bold"
+			title: "Bold",
 		},
 		{
 			name: "custom",
@@ -305,7 +305,7 @@ var easyMDE = new EasyMDE({
 				// Add your own code
 			},
 			className: "fa fa-star",
-			title: "Custom Button"
+			title: "Custom Button",
 		},
 		"|" // Separator
 		// [, ...]
@@ -342,7 +342,7 @@ var editor = new EasyMDE({
 	shortcuts: {
 		"toggleOrderedList": "Ctrl-Alt-K", // alter the shortcut for toggleOrderedList
 		"toggleCodeBlock": null, // unbind Ctrl-Alt-C
-		"drawTable": "Cmd-Alt-T" // bind Cmd-Alt-T to drawTable action, which doesn't come with a default shortcut
+		"drawTable": "Cmd-Alt-T", // bind Cmd-Alt-T to drawTable action, which doesn't come with a default shortcut
 	}
 });
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The editor is entirely customizable, from theming to toolbar buttons and javascr
   - [Useful methods](#useful-methods)
 - [How it works](#how-it-works)
 - [SimpleMDE fork](#simplemde-fork)
+- [Hacking EasyMDE](hacking-easymde)
 - [Contributing](#contributing)
 - [License](#license)
 


### PR DESCRIPTION
As suggested in [a comment](https://github.com/Ionaru/easy-markdown-editor/pull/53#issuecomment-462315603) on the PR #53, make changes on readme in the dev branch.

This includes:

- move fork explanation to the end of readme (better readability);
- add license section;
- move badges to the top (quick access);
- improve titles structure;
- add summary;
- fix typos and other minor improvements;
- add contribution guide with some love inside.

To a better understanding, all of these steps are done in separated commits but fill free to squash them.