### PR TITLE
Update markdown guide link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ horizontal-rule | drawHorizontalRule | Insert Horizontal Line<br>fa fa-minus
 preview | togglePreview | Toggle Preview<br>fa fa-eye no-disable
 side-by-side | toggleSideBySide | Toggle Side by Side<br>fa fa-columns no-disable no-mobile
 fullscreen | toggleFullScreen | Toggle Fullscreen<br>fa fa-arrows-alt no-disable no-mobile
-guide | [This link](https://simplemde.com/markdown-guide) | Markdown Guide<br>fa fa-question-circle
+guide | [This link](https://www.markdownguide.org/basic-syntax/) | Markdown Guide<br>fa fa-question-circle
 
 
 ### Toolbar customization


### PR DESCRIPTION
Since df530cf the markdown guide link is https://www.markdownguide.org/basic-syntax/ and not https://simplemde.com/markdown-guide. This PR updates the readme as well.