### PR TITLE
gulp: generate non-minified files for debug and use gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,23 +20,22 @@ var banner = ['/**',
     ' */',
     ''].join('\n');
 
-function lint() {
+gulp.task('lint', function () {
     return gulp.src('./src/js/**/*.js')
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failAfterError());
-}
+});
 
-function scripts() {
+// Browserify easymde.js
+gulp.task('build-js', function () {
     return browserify({entries: './src/js/easymde.js', standalone: 'EasyMDE'}).bundle()
-        .pipe(source('easymde.min.js'))
-        .pipe(buffer())
-        .pipe(uglify())
-        .pipe(header(banner, {pkg: pkg}))
+        .pipe(source('easymde.js'))
         .pipe(gulp.dest('./dist/'));
-}
+});
 
-function styles() {
+// Concat CSS files
+gulp.task('build-css', function () {
     var css_files = [
         './node_modules/codemirror/lib/codemirror.css',
         './src/css/*.css',
@@ -45,13 +44,25 @@ function styles() {
 
     return gulp.src(css_files)
         .pipe(concat('easymde.css'))
-        .pipe(cleanCSS())
-        .pipe(rename('easymde.min.css'))
-        .pipe(buffer())
-        .pipe(header(banner, {pkg: pkg}))
         .pipe(gulp.dest('./dist/'));
-}
+});
 
-var build = gulp.parallel(gulp.series(lint, scripts), styles);
+gulp.task('minify-js', gulp.series('build-js', function build_js() {
+    return gulp.src('./dist/easymde.js')
+        .pipe(uglify())
+        .pipe(header(banner, {pkg: pkg}))
+        .pipe(rename('easymde.min.js'))
+        .pipe(gulp.dest('./dist/'));
+}));
 
-gulp.task('default', build);
+gulp.task('minify-css', gulp.series('build-css', function minify_css() {
+    return gulp.src('./dist/easymde.css')
+        .pipe(cleanCSS())
+        .pipe(header(banner, {pkg: pkg}))
+        .pipe(rename('easymde.min.css'))
+        .pipe(gulp.dest('./dist/'));
+}));
+
+gulp.task('build', gulp.parallel('build-js', 'build-css'));
+gulp.task('minify', gulp.parallel('minify-js', 'minify-css'));
+gulp.task('default', gulp.parallel(gulp.series('lint', 'minify-js'), 'minify-css'));


### PR DESCRIPTION
This PR builds Javascript and CSS files without minifying them, useful for debugging purposes. The dist folder hierarchy is now:

```
dist
├── easymde.css
├── easymde.js
├── easymde.min.css
└── easymde.min.js
```

No more unpractical Javascript errors like "error line 7, column 291438".

It also uses gulp tasks instead of functions.

In this way we can call a specific gulp task, among `gulp lint`, `gulp build-js`, `gulp build-css`, `gulp minify-js`, `gulp minify-css`, `gulp build`, `gulp minify`, `gulp`.

edit: sorry for merge commit, you can squash it with the first one when merging to master.