### PR TITLE
Make CodeMirror object accessible.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,5 +16,8 @@
         "browser": true,
         "node": true
     },
-    "extends": "eslint:recommended"
+    "extends": "eslint:recommended",
+    "globals": {
+        "CodeMirror": true
+    }
 }

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1,6 +1,6 @@
 /*global require,module*/
 'use strict';
-var CodeMirror = require('codemirror');
+window.CodeMirror = require('codemirror');
 require('codemirror/addon/edit/continuelist.js');
 require('./codemirror/tablist');
 require('codemirror/addon/display/fullscreen.js');
@@ -1600,7 +1600,7 @@ EasyMDE.prototype.render = function (el) {
         };
     }
 
-    this.codemirror = CodeMirror.fromTextArea(el, {
+    this.codemirror = window.CodeMirror.fromTextArea(el, {
         mode: mode,
         backdrop: backdrop,
         theme: (options.theme != undefined) ? options.theme : 'easymde',


### PR DESCRIPTION
This surfaces the `CodeMirror` object as a global variable so it is available to perform advanced functions such as `CodeMirror.defineMode`, which was impossible previously.

For more information see this [SimpleMDE issue](https://github.com/sparksuite/simplemde-markdown-editor/issues/525).