### PR TITLE
fix: untoggle ordered-list items first when toggling unordered-list items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,23 +361,15 @@
             "dev": true
         },
         "async-done": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
-            "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
             "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.2",
-                "process-nextick-args": "^1.0.7",
+                "process-nextick-args": "^2.0.0",
                 "stream-exhaust": "^1.0.1"
-            },
-            "dependencies": {
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                    "dev": true
-                }
             }
         },
         "async-each": {
@@ -1162,12 +1154,13 @@
             }
         },
         "d": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.9"
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
             }
         },
         "dash-ast": {
@@ -1456,14 +1449,14 @@
             }
         },
         "es6-weak-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
             "dev": true,
             "requires": {
                 "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.1"
             }
         },
@@ -1980,8 +1973,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2002,14 +1994,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2024,20 +2014,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2154,8 +2141,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2167,7 +2153,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2182,7 +2167,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2190,14 +2174,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2216,7 +2198,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2297,8 +2278,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2310,7 +2290,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2396,8 +2375,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2433,7 +2411,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2453,7 +2430,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2497,14 +2473,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -5189,6 +5163,12 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
             "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
+        "type": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+            "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
             "dev": true
         },
         "type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,15 +361,23 @@
             "dev": true
         },
         "async-done": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
-            "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
+            "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
             "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.2",
-                "process-nextick-args": "^2.0.0",
+                "process-nextick-args": "^1.0.7",
                 "stream-exhaust": "^1.0.1"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                }
             }
         },
         "async-each": {
@@ -1154,13 +1162,12 @@
             }
         },
         "d": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.50",
-                "type": "^1.0.1"
+                "es5-ext": "^0.10.9"
             }
         },
         "dash-ast": {
@@ -1449,14 +1456,14 @@
             }
         },
         "es6-weak-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
                 "d": "1",
-                "es5-ext": "^0.10.46",
-                "es6-iterator": "^2.0.3",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
                 "es6-symbol": "^3.1.1"
             }
         },
@@ -1973,7 +1980,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1994,12 +2002,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2014,17 +2024,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2141,7 +2154,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2153,6 +2167,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2167,6 +2182,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2174,12 +2190,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2198,6 +2216,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2278,7 +2297,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2290,6 +2310,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2375,7 +2396,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2411,6 +2433,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2430,6 +2453,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2473,12 +2497,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -5163,12 +5189,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
             "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-            "dev": true
-        },
-        "type": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-            "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
             "dev": true
         },
         "type-check": {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -126,7 +126,7 @@ function createToolbarButton(options, enableTooltips, shortcuts) {
 	if( options.name && options.name in shortcuts ){
 		bindings[options.name] = options.action;
     }
-    
+
     if (options.title && enableTooltips) {
         el.title = createTooltip(options.title, options.action, shortcuts);
 
@@ -988,11 +988,25 @@ function _toggleLine(cm, name) {
         var map = {
             'quote': '>',
             'unordered-list': '*',
-            'ordered-list': 'd+.',
+            'ordered-list': '\\d+.',
         };
         var rt = new RegExp(map[name]);
 
         return char && rt.test(char);
+    };
+
+    var _do = function (name, text, untoggleOnly) {
+        var arr = listRegexp.exec(text);
+        var char = _getChar(name, line);
+        if (arr !== null) {
+            if (_checkChar(name, arr[2])) {
+                char = '';
+            }
+            text = arr[1] + char + arr[3] + text.replace(whitespacesRegexp, '').replace(repl[name], '$1');
+        } else if (untoggleOnly == false){
+            text = char + ' ' + text;
+        }
+        return text;
     };
 
     var line = 1;
@@ -1002,16 +1016,13 @@ function _toggleLine(cm, name) {
             if (stat[name]) {
                 text = text.replace(repl[name], '$1');
             } else {
-                var arr = listRegexp.exec(text);
-                var char = _getChar(name, line);
-                if (arr !== null) {
-                    if (_checkChar(name, arr[2])) {
-                        char = '';
-                    }
-                    text = arr[1] + char + arr[3] + text.replace(whitespacesRegexp, '').replace(repl[name], '$1');
-                } else {
-                    text = char + ' ' + text;
+                // If we're toggling unordered-list formatting, check if the current line
+                // is part of an ordered-list, and if so, untoggle that first.
+                // Workaround for https://github.com/Ionaru/easy-markdown-editor/issues/92
+                if (name == 'unordered-list') {
+                    text = _do('ordered-list', text, true);
                 }
+                text = _do(name, text, false);
                 line += 1;
             }
             cm.replaceRange(text, {
@@ -1367,6 +1378,7 @@ var blockStyles = {
  * Interface of EasyMDE.
  */
 function EasyMDE(options) {
+    console.log('oh hai');
     // Handle options parameter
     options = options || {};
 
@@ -1684,22 +1696,22 @@ EasyMDE.prototype.autosave = function () {
             console.log('EasyMDE: You must set a uniqueId to use the autosave feature');
             return;
         }
-        
+
         if(this.options.autosave.binded !== true) {
           if (easyMDE.element.form != null && easyMDE.element.form != undefined) {
               easyMDE.element.form.addEventListener('submit', function () {
                   clearTimeout(easyMDE.autosaveTimeoutId);
                   easyMDE.autosaveTimeoutId = undefined;
-                
+
                   localStorage.removeItem('smde_' + easyMDE.options.autosave.uniqueId);
-                  
+
                   // Restart autosaving in case the submit will be cancelled down the line
                   setTimeout(function() {
                     easyMDE.autosave();
                   }, easyMDE.options.autosave.delay || 10000);
               });
           }
-          
+
           this.options.autosave.binded = true;
         }
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -995,7 +995,7 @@ function _toggleLine(cm, name) {
         return char && rt.test(char);
     };
 
-    var _do = function (name, text, untoggleOnly) {
+    var _toggle = function (name, text, untoggleOnly) {
         var arr = listRegexp.exec(text);
         var char = _getChar(name, line);
         if (arr !== null) {
@@ -1020,9 +1020,9 @@ function _toggleLine(cm, name) {
                 // is part of an ordered-list, and if so, untoggle that first.
                 // Workaround for https://github.com/Ionaru/easy-markdown-editor/issues/92
                 if (name == 'unordered-list') {
-                    text = _do('ordered-list', text, true);
+                    text = _toggle('ordered-list', text, true);
                 }
-                text = _do(name, text, false);
+                text = _toggle(name, text, false);
                 line += 1;
             }
             cm.replaceRange(text, {
@@ -1378,7 +1378,6 @@ var blockStyles = {
  * Interface of EasyMDE.
  */
 function EasyMDE(options) {
-    console.log('oh hai');
     // Handle options parameter
     options = options || {};
 


### PR DESCRIPTION
Fix for [#92](https://github.com/Ionaru/easy-markdown-editor/issues/92)

When you attempt to run `toggleUnorderedList` on text containing existing ordered list items, it fails and throws an error in the console. 

This is a workaround which first attempts to detect and untoggle any ordered items in the line before applying unordered formatting. 