### PR TITLE
Fix for hyperlink doubling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!--## [Unreleased]-->
+## Fixed
+- Hyperlink text getting doubled each time click on link ([#25])
+
 ## [2.6.1] - 2019-06-17
 ### Fixed
 - Error when toggling between ordered and unordered lists (Thanks to [@roryok], [#93]).


### PR DESCRIPTION
Click on link multiple times no longer doubles the output, instead it now toggles the link on and off.

Same functionality was applied to image link.