### PR TITLE
Allow custom upload function

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,13 @@ easyMDE.value('New input for **EasyMDE**');
 - **uploadImage**: If set to `true`, enables the image upload functionality, which can be triggered by drag&drop, copy-paste and through the browse-file window (opened when the user click on the *upload-image* icon). Defaults to `false`.
 - **imageMaxSize**: Maximum image size in bytes, checked before upload (note: never trust client, always check image size at server-side). Defaults to `1024*1024*2` (2Mb).
 - **imageAccept**: A comma-separated list of mime-types used to check image type before upload (note: never trust client, always check file types at server-side). Defaults to `image/png, image/jpeg`.
+- **imageUploadFunction**: A custom function for handling the image upload. Using this function will render the options `imageMaxSize`, `imageAccept`, `imageUploadEndpoint` and `imageCSRFToken` ineffective.
+    - The function gets a file and onSuccess and onError callback functions as parameters. `onSuccess(imageUrl: string)` and `onError(errorMessage: string)`
 - **imageUploadEndpoint**: The endpoint where the images data will be sent, via an asynchronous *POST* request. The server is supposed to save this image, and return a json response.
      - if the request was successfully processed (HTTP 200-OK): `{"data": {"filePath": "<filePath>"}}` where *filePath* is the relative path of the image;
      - otherwise: `{"error": "<errorCode>"}`, where *errorCode* can be `noFileGiven` (HTTP 400), `typeNotAllowed` (HTTP 415), `fileTooLarge` (HTTP 413) or `importError` (see *errorMessages* below). If *errorCode* is not one of the *errorMessages*, it is alerted unchanged to the user. This allows for server side error messages.
      No default value.
-- **imageCSRFToken**: CSRF token to include with AJAX call to upload image. For instance used with Django backend. 
+- **imageCSRFToken**: CSRF token to include with AJAX call to upload image. For instance used with Django backend.
 - **imageTexts**: Texts displayed to the user (mainly on the status bar) for the import image feature, where `#image_name#`, `#image_size#` and `#image_max_size#` will replaced by their respective values, that can be used for customization or internationalization:
     - **sbInit**: Status message displayed initially if `uploadImage` is set to `true`. Defaults to `Attach files by drag and dropping or pasting from clipboard.`.
     - **sbOnDragEnter**: Status message displayed when the user drags a file to the text area. Defaults to `Drop image to upload it.`.

--- a/types/easymde-test.ts
+++ b/types/easymde-test.ts
@@ -92,8 +92,10 @@ const editorImagesCustom = new EasyMDE({
     imageAccept: 'image/png, image/bmp',
     imageCSRFToken: undefined,
     imageMaxSize: 10485760,
-    imageUploadFunction: (file: File, onSuccess: Function, onError: Function) => {
-        console.log(file)
+    imageUploadFunction: (file: File, onSuccess, onError) => {
+        console.log(file);
+        onSuccess('http://image.url/9.png');
+        onError('Failed because reasons.');
     },
     imageTexts: {
         sbInit: 'Drag & drop images!',

--- a/types/easymde-test.ts
+++ b/types/easymde-test.ts
@@ -1,4 +1,6 @@
 // Create new instance
+import EasyMDE = require('./easymde');
+
 const editor = new EasyMDE({
     autoDownloadFontAwesome: false,
     element: document.getElementById('mdEditor')!,
@@ -40,7 +42,7 @@ const editor2 = new EasyMDE({
         title: 'Bold',
     }, '|', { // Separator
         name: 'alert',
-        action: (editor) => {
+        action: (editor: EasyMDE) => {
             alert('This is from a custom button action!');
             // Custom functions have access to the `editor` instance.
         },
@@ -84,3 +86,30 @@ const editorImages = new EasyMDE({
         console.error(errorMessage);
     },
 });
+
+const editorImagesCustom = new EasyMDE({
+    uploadImage: true,
+    imageAccept: 'image/png, image/bmp',
+    imageCSRFToken: undefined,
+    imageMaxSize: 10485760,
+    imageUploadFunction: (file: File, onSuccess: Function, onError: Function) => {
+        console.log(file)
+    },
+    imageTexts: {
+        sbInit: 'Drag & drop images!',
+        sbOnDragEnter: 'Let it go, let it go',
+        sbOnDrop: 'Uploading...',
+        sbProgress: 'Uploading... (#progress#)',
+        sbOnUploaded: 'Upload complete!',
+        sizeUnits: 'b,Kb,Mb'
+    },
+    errorMessages: {
+        noFileGiven: 'Please select a file',
+        typeNotAllowed: 'This file type is not allowed!',
+        fileTooLarge: 'Image too big',
+        importError: 'Something went oops!',
+    },
+    errorCallback: (errorMessage) => {
+        console.error(errorMessage);
+    },
+  });

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -134,6 +134,7 @@ declare namespace EasyMDE {
         uploadImage?: boolean;
         imageMaxSize?: number;
         imageAccept?: string;
+        imageUploadFunction?: (file: File, onSuccess: Function, onError: Function) => void;
         imageUploadEndpoint?: string;
         imageCSRFToken?: string;
         imageTexts?: ImageTextsOptions;

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -134,7 +134,7 @@ declare namespace EasyMDE {
         uploadImage?: boolean;
         imageMaxSize?: number;
         imageAccept?: string;
-        imageUploadFunction?: (file: File, onSuccess: Function, onError: Function) => void;
+        imageUploadFunction?: (file: File, onSuccess: (url: string) => void, onError: (error: string) => void) => void;
         imageUploadEndpoint?: string;
         imageCSRFToken?: string;
         imageTexts?: ImageTextsOptions;


### PR DESCRIPTION
This PR adds the possibility to use a custom upload function. This could be useful when you can't use an ajax call because you have to call a REST API with a JWT Token or you want to use a third-party service in the cloud.

Example of use:

```
var editor = new EasyMDE({
    uploadImage: true,
    imageUploadFunction: function(file, onSuccess, onError) {
        try {
            var imageUrl = uploadImage(file)
            onSuccess(imageUrl)
        } catch (error) {
            console.log(error)
            onError(error)
        }
    },
});
```