### PR TITLE
feat: add missing minHeight attribute to Option interface

### DIFF
--- a/types/easymde-test.ts
+++ b/types/easymde-test.ts
@@ -15,6 +15,7 @@ const editor = new EasyMDE({
         console.log('FullscreenToggled', full);
     },
     theme: 'someOtherTheme',
+    minHeight: '200px'
 });
 
 // Editor functions
@@ -35,29 +36,36 @@ EasyMDE.toggleItalic = (editor: EasyMDE) => {
 const editor2 = new EasyMDE({
     autoDownloadFontAwesome: undefined,
     previewClass: ['my-custom-class', 'some-other-class'],
-    toolbar: [{
-        name: 'bold',
-        action: EasyMDE.toggleBold,
-        className: 'fa fa-bolt',
-        title: 'Bold',
-    }, '|', { // Separator
-        name: 'alert',
-        action: (editor: EasyMDE) => {
-            alert('This is from a custom button action!');
-            // Custom functions have access to the `editor` instance.
+    toolbar: [
+        {
+            name: 'bold',
+            action: EasyMDE.toggleBold,
+            className: 'fa fa-bolt',
+            title: 'Bold'
         },
-        className: 'fa fa-star',
-        title: 'A Custom Button',
-        noDisable: undefined,
-        noMobile: false,
-    }, '|', {
-        name: 'link',
-        action: 'https://github.com/Ionaru/easy-markdown-editor',
-        className: 'fa fab fa-github',
-        title: 'A Custom Link',
-        noDisable: true,
-        noMobile: true,
-    }]
+        '|',
+        {
+            // Separator
+            name: 'alert',
+            action: (editor: EasyMDE) => {
+                alert('This is from a custom button action!');
+                // Custom functions have access to the `editor` instance.
+            },
+            className: 'fa fa-star',
+            title: 'A Custom Button',
+            noDisable: undefined,
+            noMobile: false
+        },
+        '|',
+        {
+            name: 'link',
+            action: 'https://github.com/Ionaru/easy-markdown-editor',
+            className: 'fa fab fa-github',
+            title: 'A Custom Link',
+            noDisable: true,
+            noMobile: true
+        }
+    ]
 });
 
 editor2.clearAutosavedValue();
@@ -80,11 +88,11 @@ const editorImages = new EasyMDE({
         noFileGiven: 'Please select a file',
         typeNotAllowed: 'This file type is not allowed!',
         fileTooLarge: 'Image too big',
-        importError: 'Something went oops!',
+        importError: 'Something went oops!'
     },
-    errorCallback: (errorMessage) => {
+    errorCallback: errorMessage => {
         console.error(errorMessage);
-    },
+    }
 });
 
 const editorImagesCustom = new EasyMDE({
@@ -109,9 +117,9 @@ const editorImagesCustom = new EasyMDE({
         noFileGiven: 'Please select a file',
         typeNotAllowed: 'This file type is not allowed!',
         fileTooLarge: 'Image too big',
-        importError: 'Something went oops!',
+        importError: 'Something went oops!'
     },
-    errorCallback: (errorMessage) => {
+    errorCallback: errorMessage => {
         console.error(errorMessage);
-    },
-  });
+    }
+});

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -114,6 +114,7 @@ declare namespace EasyMDE {
         initialValue?: string;
         insertTexts?: InsertTextOptions;
         lineWrapping?: boolean;
+        minHeight?: string;
         parsingConfig?: ParsingOptions;
         placeholder?: string;
         previewClass?: string | ReadonlyArray<string>;


### PR DESCRIPTION
The `minHeight` attribute is missing from the type definition: `Options` interface.

It's listed here: https://github.com/Ionaru/easy-markdown-editor#options-list, and available on the JS version.