### PR TITLE
Differentiate between regular autosave delay and submit autosave delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to easymde will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!--## [Unreleased]-->
+## [Unreleased]
+### Changed
+- Delay before assuming that submit of the form as failed is `autosave.submit_delay` instead of `autosave.delay` ([#139]).
+
 ## [2.9.0] - 2020-01-13
 ### Added
 - Missing minHeight option in type definition (Thanks to [@t49tran], [#123]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Delay before assuming that submit of the form as failed is `autosave.submit_delay` instead of `autosave.delay` ([#139]).
+- Delay before assuming that submit of the form as failed is `autosave.submit_delay` instead of `autosave.delay` (Thanks to [@Situphen], [#139]).
 
 ## [2.9.0] - 2020-01-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ easyMDE.value('New input for **EasyMDE**');
 - **autosave**: *Saves the text that's being written and will load it back in the future. It will forget the text when the form it's contained in is submitted.*
   - **enabled**: If set to `true`, saves the text automatically. Defaults to `false`.
   - **delay**: Delay between saves, in milliseconds. Defaults to `10000` (10s).
-  - **submit_delay**: Delay before assuming that submit of the form failed and saving the text, in milliseconds. Defaults to `10000` (10s).
+  - **submit_delay**: Delay before assuming that submit of the form failed and saving the text, in milliseconds. Defaults to `autosave.delay` or `10000` (10s).
   - **uniqueId**: You must set a unique string identifier so that EasyMDE can autosave. Something that separates this from other instances of EasyMDE elsewhere on your website.
 - **blockStyles**: Customize how certain buttons that style blocks of text behave.
   - **bold**: Can be set to `**` or `__`. Defaults to `**`.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ easyMDE.value('New input for **EasyMDE**');
 - **autosave**: *Saves the text that's being written and will load it back in the future. It will forget the text when the form it's contained in is submitted.*
   - **enabled**: If set to `true`, saves the text automatically. Defaults to `false`.
   - **delay**: Delay between saves, in milliseconds. Defaults to `10000` (10s).
+  - **submit_delay**: Delay before assuming that submit of the form failed and saving the text, in milliseconds. Defaults to `10000` (10s).
   - **uniqueId**: You must set a unique string identifier so that EasyMDE can autosave. Something that separates this from other instances of EasyMDE elsewhere on your website.
 - **blockStyles**: Customize how certain buttons that style blocks of text behave.
   - **bold**: Can be set to `**` or `__`. Defaults to `**`.
@@ -201,6 +202,7 @@ var editor = new EasyMDE({
 		enabled: true,
 		uniqueId: "MyUniqueID",
 		delay: 1000,
+		submit_delay: 5000,
 	},
 	blockStyles: {
 		bold: "__",

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1929,7 +1929,7 @@ EasyMDE.prototype.autosave = function () {
                     // Restart autosaving in case the submit will be cancelled down the line
                     setTimeout(function () {
                         easyMDE.autosave();
-                    }, easyMDE.options.autosave.submit_delay || 10000);
+                    }, easyMDE.options.autosave.submit_delay || easyMDE.options.autosave.delay || 10000);
                 });
             }
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1929,7 +1929,7 @@ EasyMDE.prototype.autosave = function () {
                     // Restart autosaving in case the submit will be cancelled down the line
                     setTimeout(function () {
                         easyMDE.autosave();
-                    }, easyMDE.options.autosave.delay || 10000);
+                    }, easyMDE.options.autosave.submit_delay || 10000);
                 });
             }
 


### PR DESCRIPTION
Differentiate between : 

- the "regular" autosave delay (saving the content every x seconds) with `options.autosave.delay`
- the "submit" autosave delay (saving the content if we think the submit as failed) with `options.autosave.submit_delay`

I'm working for a project (https://github.com/zestedesavoir/zds-site) where we put the `options.autosave.delay` at 1 second because we want to save the content each 1 second. But since the submit request takes more than 1 second EasyMDE thinks the submit as failed so it saves the content in the `localStorage`.

I didn't find a better name than `autosave.submit_delay`, any suggestion is welcome.

This might be considered as a breaking change. If it is the case, we could maybe use `easyMDE.options.autosave.submit_delay || easyMDE.options.autosave.delay || 10000` ?