### PR TITLE
Allow custom sanitize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **hljs**: An injectible instance of [highlight.js](https://github.com/isagalaev/highlight.js). If you don't want to rely on the global namespace (`window.hljs`), you can provide an instance here. Defaults to `undefined`.
   - **markedOptions**: Set the internal Markdown renderer's [options](https://marked.js.org/#/USING_ADVANCED.md#options). Other `renderingConfig` options will take precedence.
   - **singleLineBreaks**: If set to `false`, disable parsing GFM single line breaks. Defaults to `true`.
+  - **sanitizerFunction**: Custom function for sanitizing the HTML output of markdown renderer.
 - **shortcuts**: Keyboard shortcuts associated with this instance. Defaults to the [array of shortcuts](#keyboard-shortcuts).
 - **showIcons**: An array of icon names to show. Can be used to show specific icons hidden by default without completely customizing the toolbar.
 - **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.
@@ -251,6 +252,10 @@ var editor = new EasyMDE({
 	renderingConfig: {
 		singleLineBreaks: false,
 		codeSyntaxHighlighting: true,
+		sanitizerFunction: function(renderedHTML) {
+			// Using DOMPurify and only allowing <b> tags
+			return DOMPurify.sanitize(renderedHTML, {ALLOWED_TAGS: ['b']})
+		},
 	},
 	shortcuts: {
 		drawTable: "Cmd-Alt-T"

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1762,6 +1762,11 @@ EasyMDE.prototype.markdown = function (text) {
 
         // Convert the markdown to HTML
         var htmlText = marked(text);
+        
+        // Sanitize HTML
+        if (this.options.renderingConfig && typeof this.options.renderingConfig.sanitizerFunction === 'function') {
+            htmlText = this.options.renderingConfig.sanitizerFunction(htmlText);
+        }
 
         // Edit the HTML anchors to add 'target="_blank"' by default.
         htmlText = addAnchorTargetBlank(htmlText);


### PR DESCRIPTION
As per https://github.com/markedjs/marked/pull/1519, markedjs is deprecating their sanitizer options. EasyMDE currently doesn't allow any other options for sanitizing the markdown preview.

They are suggesting using an external sanitization library such as [DOMPurify](https://github.com/cure53/DOMPurify) (recommended), [sanitize-html](https://github.com/apostrophecms/sanitize-html) or [insane](https://github.com/bevacqua/insane). As they have slightly different API's for handling their options I suggest simply providing the option to wrap the markedjs HTML output in a custom sanitizer function, which can accommodate any external library.

```js
function(renderedHTML) {
	// Using DOMPurify with options
	return DOMPurify.sanitize(renderedHTML, {ALLOWED_TAGS: ['b']})
}
```