### PR TITLE
Option to set a specified version of FontAwesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ easyMDE.value('New input for **EasyMDE**');
 ### Options list
 
 - **autoDownloadFontAwesome**: If set to `true`, force downloads Font Awesome (used for icons). If set to `false`, prevents downloading. Defaults to `undefined`, which will intelligently check whether Font Awesome has already been included, then download accordingly.
+- **versionFontAwesome**: Got a specified version of Font Awesome. e.g.:`5.12.1`
 - **autofocus**: If set to `true`, focuses the editor automatically. Defaults to `false`.
 - **autosave**: *Saves the text that's being written and will load it back in the future. It will forget the text when the form it's contained in is submitted.*
   - **enabled**: If set to `true`, saves the text automatically. Defaults to `false`.

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1529,20 +1529,32 @@ function EasyMDE(options) {
 
     if (options.autoDownloadFontAwesome !== true) {
         var styleSheets = document.styleSheets;
-        for (var i = 0; i < styleSheets.length; i++) {
-            if (!styleSheets[i].href)
+        var urls = [
+            '//maxcdn.bootstrapcdn.com/font-awesome/',
+            '//cdnjs.cloudflare.com/ajax/libs/font-awesome/',
+        ];
+        for (var i = 0, href; i < styleSheets.length; i++) {
+            href = styleSheets[i].href;
+
+            if (!href)
                 continue;
 
-            if (styleSheets[i].href.indexOf('//maxcdn.bootstrapcdn.com/font-awesome/') > -1) {
-                autoDownloadFA = false;
-            }
+            if (!urls.filter(function (url) { return href.indexOf(url) > -1; }).length)
+                continue;
+
+            autoDownloadFA = false;
         }
     }
 
     if (autoDownloadFA) {
         var link = document.createElement('link');
+        var version = options.versionFontAwesome;
+
         link.rel = 'stylesheet';
-        link.href = 'https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css';
+        if (typeof version === 'string') // cdnjs has the recent version
+            link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/' + version + '/css/all.min.css';
+        else
+            link.href = 'https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css';
         document.getElementsByTagName('head')[0].appendChild(link);
     }
 


### PR DESCRIPTION
The last version of FA available in `https://maxcdn.bootstrapcdn.com/` is 4.7 instead of 5.12...

Can we add the choice of the version ? Or does the developper have to add themself the css link ?