### PR TITLE
Add support for custom icon markup

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -168,13 +168,12 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
     }
 
     // Prevent errors if there is no class name in custom options
-    var className = '';
+    var classNameParts = [];
     if(typeof options.className !== 'undefined') {
-        className = options.className;
+        classNameParts = options.className.split(' ');
     }
 
     // Provide backwards compatibility with simple-markdown-editor by adding custom classes to the button.
-    var classNameParts = className.split(' ');
     var iconClasses = [];
     for (var classNameIndex = 0; classNameIndex < classNameParts.length; classNameIndex++) {
         var classNamePart = classNameParts[classNameIndex];

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -167,29 +167,35 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
         el.classList.add('no-mobile');
     }
 
-    // Provide backwards compatibility with simple-markdown-editor by adding custom classes to the button.
-    var classNameParts = options.className.split(' ');
-    var iconClasses = [];
-    for (var classNameIndex = 0; classNameIndex < classNameParts.length; classNameIndex++) {
-        var classNamePart = classNameParts[classNameIndex];
-        // Split icon classes from the button.
-        // Regex will detect "fa", "fas", "fa-something" and "fa-some-icon-1", but not "fanfare".
-        if (classNamePart.match(/^fa([srlb]|(-[\w-]*)|$)/)) {
-            iconClasses.push(classNamePart);
-        } else {
-            el.classList.add(classNamePart);
+    // If there is a custom icon, use that
+    if (typeof options.icon !== 'undefined') {
+        el.innerHTML = options.icon;
+    } else {
+        // Provide backwards compatibility with simple-markdown-editor by adding custom classes to the button.
+
+        var classNameParts = options.className.split(' ');
+        var iconClasses = [];
+        for (var classNameIndex = 0; classNameIndex < classNameParts.length; classNameIndex++) {
+            var classNamePart = classNameParts[classNameIndex];
+            // Split icon classes from the button.
+            // Regex will detect "fa", "fas", "fa-something" and "fa-some-icon-1", but not "fanfare".
+            if (classNamePart.match(/^fa([srlb]|(-[\w-]*)|$)/)) {
+                iconClasses.push(classNamePart);
+            } else {
+                el.classList.add(classNamePart);
+            }
         }
-    }
 
-    el.tabIndex = -1;
+        el.tabIndex = -1;
 
-    // Create icon element and append as a child to the button
-    var icon = document.createElement('i');
-    for (var iconClassIndex = 0; iconClassIndex < iconClasses.length; iconClassIndex++) {
-        var iconClass = iconClasses[iconClassIndex];
-        icon.classList.add(iconClass);
+        // Create icon element and append as a child to the button
+        var icon = document.createElement('i');
+        for (var iconClassIndex = 0; iconClassIndex < iconClasses.length; iconClassIndex++) {
+            var iconClass = iconClasses[iconClassIndex];
+            icon.classList.add(iconClass);
+        }
+        el.appendChild(icon);
     }
-    el.appendChild(icon);
 
     if (options.action && enableActions) {
         if (typeof options.action === 'function') {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -172,7 +172,6 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
         el.innerHTML = options.icon;
     } else {
         // Provide backwards compatibility with simple-markdown-editor by adding custom classes to the button.
-
         var classNameParts = options.className.split(' ');
         var iconClasses = [];
         for (var classNameIndex = 0; classNameIndex < classNameParts.length; classNameIndex++) {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -167,33 +167,39 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
         el.classList.add('no-mobile');
     }
 
-    // If there is a custom icon, use that
+    // Prevent errors if there is no class name in custom options
+    var className = '';
+    if(typeof options.className !== 'undefined') {
+        className = options.className;
+    }
+
+    // Provide backwards compatibility with simple-markdown-editor by adding custom classes to the button.
+    var classNameParts = className.split(' ');
+    var iconClasses = [];
+    for (var classNameIndex = 0; classNameIndex < classNameParts.length; classNameIndex++) {
+        var classNamePart = classNameParts[classNameIndex];
+        // Split icon classes from the button.
+        // Regex will detect "fa", "fas", "fa-something" and "fa-some-icon-1", but not "fanfare".
+        if (classNamePart.match(/^fa([srlb]|(-[\w-]*)|$)/)) {
+            iconClasses.push(classNamePart);
+        } else {
+            el.classList.add(classNamePart);
+        }
+    }
+
+    el.tabIndex = -1;
+
+    // Create icon element and append as a child to the button
+    var icon = document.createElement('i');
+    for (var iconClassIndex = 0; iconClassIndex < iconClasses.length; iconClassIndex++) {
+        var iconClass = iconClasses[iconClassIndex];
+        icon.classList.add(iconClass);
+    }
+    el.appendChild(icon);
+
+    // If there is a custom icon markup set, use that
     if (typeof options.icon !== 'undefined') {
         el.innerHTML = options.icon;
-    } else {
-        // Provide backwards compatibility with simple-markdown-editor by adding custom classes to the button.
-        var classNameParts = options.className.split(' ');
-        var iconClasses = [];
-        for (var classNameIndex = 0; classNameIndex < classNameParts.length; classNameIndex++) {
-            var classNamePart = classNameParts[classNameIndex];
-            // Split icon classes from the button.
-            // Regex will detect "fa", "fas", "fa-something" and "fa-some-icon-1", but not "fanfare".
-            if (classNamePart.match(/^fa([srlb]|(-[\w-]*)|$)/)) {
-                iconClasses.push(classNamePart);
-            } else {
-                el.classList.add(classNamePart);
-            }
-        }
-
-        el.tabIndex = -1;
-
-        // Create icon element and append as a child to the button
-        var icon = document.createElement('i');
-        for (var iconClassIndex = 0; iconClassIndex < iconClasses.length; iconClassIndex++) {
-            var iconClass = iconClasses[iconClassIndex];
-            icon.classList.add(iconClass);
-        }
-        el.appendChild(icon);
     }
 
     if (options.action && enableActions) {


### PR DESCRIPTION
Resolves #137

This PR adds support for an extra `icon` option to customize the toolbar icons with custom markdown. My use case for this is using svg-icons from other places than font awesome.

If the `icon` property exists, it will be used, ignoring any settings from `className`.

Currently, this is more a proof of concept, at least docs about this should be added. I'm open to any suggestions about how this could be done better.

It can be used like this:

```javascript
var easyMDE = new EasyMDE({
    toolbar: [
        {
            name: 'Beer',
            action: EasyMDE.toggleBold,
            title: 'Bold',
            icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M368 96h-48V56c0-13.255-10.745-24-24-24H24C10.745 32 0 42.745 0 56v400c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24v-42.11l80.606-35.977C429.396 365.063 448 336.388 448 304.86V176c0-44.112-35.888-80-80-80zm16 208.86a16.018 16.018 0 0 1-9.479 14.611L320 343.805V160h48c8.822 0 16 7.178 16 16v128.86zM208 384c-8.836 0-16-7.164-16-16V144c0-8.836 7.164-16 16-16s16 7.164 16 16v224c0 8.836-7.164 16-16 16zm-96 0c-8.836 0-16-7.164-16-16V144c0-8.836 7.164-16 16-16s16 7.164 16 16v224c0 8.836-7.164 16-16 16z" class=""></path></svg>'
        }
    ]
});
```

Result:
![image](https://user-images.githubusercontent.com/13721712/76690618-fe164080-6641-11ea-8fa4-c8197e6c7764.png)

(The styling of the icon could be improved, but I'm not sure if it would be easyMDEs job to do this since it can only make assumptions about the contents of the `icon` property. Therefore, styling should be the responsability of the caller IMHO.)