### PR TITLE
Set .CodeMirror z-index to 0

### DIFF
--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -6,7 +6,7 @@
     border-bottom-right-radius: 4px;
     padding: 10px;
     font: inherit;
-    z-index: 1;
+    z-index: 0;
     word-wrap: break-word;
 }
 


### PR DESCRIPTION
When using `easy-markdown-editor` in context with other packages to build forms. The `easy-markdown-editor` package causes problems with the stacking order. 

Setting the base z-index to `0` instead of `1` will solve this issue

# Example
[easy-markdown-editor](https://github.com/Ionaru/easy-markdown-editor) used together with [react-select](https://react-select.com/home)
## Before
![Screenshot 2020-03-25 at 17 27 47](https://user-images.githubusercontent.com/11800807/77560765-2877c180-6ebe-11ea-8124-16bc27d74f4f.png)

## After
![Screenshot 2020-03-25 at 17 27 57](https://user-images.githubusercontent.com/11800807/77560786-2dd50c00-6ebe-11ea-9278-ac5a31841b15.png)

