### PR TITLE
Update Marked dependency to 0.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3625,9 +3625,9 @@
             }
         },
         "marked": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.1.tgz",
-            "integrity": "sha512-tZfJS8uE0zpo7xpTffwFwYRfW9AzNcdo04Qcjs+C9+oCy8MSRD2reD5iDVtYx8mtLaqsGughw/YLlcwNxAHA1g=="
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+            "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
         },
         "matchdep": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "codemirror": "^5.52.2",
         "codemirror-spell-checker": "1.1.2",
-        "marked": "^0.8.0"
+        "marked": "^0.8.2"
     },
     "devDependencies": {
         "@types/codemirror": "0.0.88",


### PR DESCRIPTION
This PR aims to fix the following [typescript errors in the react-simple-editor package](https://github.com/RIP21/react-simplemde-editor/pull/119) which relies on `easymde`