### PR TITLE
fix #181 : allow saving only on change content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for Node.js 14.
 - Preview without fullscreen (Thanks to [@nick-denry], [#196]).
+- `autosave.saveOnChangeText` option to save the text only when modifying the content of the easymde instance (Thanks to [@firm1], [#181]).
 
 ### Fixed
 - Fix cursor displayed position on activity ([#183]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for Node.js 14.
 - Preview without fullscreen (Thanks to [@nick-denry], [#196]).
-- `autosave.saveOnChangeText` option to save the text only when modifying the content of the easymde instance (Thanks to [@firm1], [#181]).
 
 ### Fixed
 - Fix cursor displayed position on activity ([#183]).
 - Checkboxes always have bullets in front of them ([#136]).
+- Save the text only when modifying the content of the easymde instance (Thanks to [@firm1], [#181]).
 
 ## [2.10.1] - 2020-04-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ easyMDE.value('New input for **EasyMDE**');
   - **enabled**: If set to `true`, saves the text automatically. Defaults to `false`.
   - **delay**: Delay between saves, in milliseconds. Defaults to `10000` (10s).
   - **submit_delay**: Delay before assuming that submit of the form failed and saving the text, in milliseconds. Defaults to `autosave.delay` or `10000` (10s).
-  - **saveOnChangeText**: Saves the text only when the content has been changed. Without this parameter, the text will be saved periodically according to the `autosave.delay` parameter.
   - **uniqueId**: You must set a unique string identifier so that EasyMDE can autosave. Something that separates this from other instances of EasyMDE elsewhere on your website.
   - **timeFormat**: Set DateTimeFormat. More information see [DateTimeFormat instances](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat). Default `locale: en-US, format: hour:minute`.
   - **text**: Set text for autosave.
@@ -211,7 +210,6 @@ var editor = new EasyMDE({
 		uniqueId: "MyUniqueID",
 		delay: 1000,
 		submit_delay: 5000,
-		saveOnChangeText: true,
 		timeFormat: {
 			locale: 'en-US',
 			format: {

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **enabled**: If set to `true`, saves the text automatically. Defaults to `false`.
   - **delay**: Delay between saves, in milliseconds. Defaults to `10000` (10s).
   - **submit_delay**: Delay before assuming that submit of the form failed and saving the text, in milliseconds. Defaults to `autosave.delay` or `10000` (10s).
+  - **saveOnChangeText**: Saves the text only when the content has been changed. Without this parameter, the text will be saved periodically according to the `autosave.delay` parameter.
   - **uniqueId**: You must set a unique string identifier so that EasyMDE can autosave. Something that separates this from other instances of EasyMDE elsewhere on your website.
   - **timeFormat**: Set DateTimeFormat. More information see [DateTimeFormat instances](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat). Default `locale: en-US, format: hour:minute`.
   - **text**: Set text for autosave.
@@ -210,6 +211,7 @@ var editor = new EasyMDE({
 		uniqueId: "MyUniqueID",
 		delay: 1000,
 		submit_delay: 5000,
+		saveOnChangeText: true,
 		timeFormat: {
 			locale: 'en-US',
 			format: {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2037,7 +2037,8 @@ EasyMDE.prototype.render = function (el) {
     if (options.autosave != undefined && options.autosave.enabled === true) {
         this.autosave(); // use to load localstorage content
         this.codemirror.on('change', function () {
-            setTimeout(function () {
+            clearTimeout(self._autosave_timeout);
+            self._autosave_timeout = setTimeout(function () {
                 self.autosave();
             }, self.options.autosave.submit_delay || self.options.autosave.delay || 1000);
         });
@@ -2072,6 +2073,7 @@ function isLocalStorageAvailable() {
 }
 
 EasyMDE.prototype.autosave = function () {
+    console.log('save');
     if (isLocalStorageAvailable()) {
         var easyMDE = this;
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2035,16 +2035,12 @@ EasyMDE.prototype.render = function (el) {
         this.gui.statusbar = this.createStatusbar();
     }
     if (options.autosave != undefined && options.autosave.enabled === true) {
-        if(this.options.autosave.saveOnChangeText !== undefined && this.options.autosave.saveOnChangeText === true) {
-            this.autosave(false); // use to load localstorage content
-            this.codemirror.on('change', function () {
-                setTimeout(function () {
-                    self.autosave(false);
-                }, self.options.autosave.submit_delay || self.options.autosave.delay || 1000);
-            });
-        } else {
-            this.autosave(true);
-        }
+        this.autosave(); // use to load localstorage content
+        this.codemirror.on('change', function () {
+            setTimeout(function () {
+                self.autosave();
+            }, self.options.autosave.submit_delay || self.options.autosave.delay || 1000);
+        });
     }
 
     this.gui.sideBySide = this.createSideBySide();
@@ -2075,7 +2071,7 @@ function isLocalStorageAvailable() {
     return true;
 }
 
-EasyMDE.prototype.autosave = function (repeatSaving) {
+EasyMDE.prototype.autosave = function () {
     if (isLocalStorageAvailable()) {
         var easyMDE = this;
 
@@ -2091,13 +2087,6 @@ EasyMDE.prototype.autosave = function (repeatSaving) {
                     easyMDE.autosaveTimeoutId = undefined;
 
                     localStorage.removeItem('smde_' + easyMDE.options.autosave.uniqueId);
-
-                    // Restart autosaving in case the submit will be cancelled down the line
-                    if (repeatSaving === true) {
-                        setTimeout(function () {
-                            easyMDE.autosave(repeatSaving);
-                        }, easyMDE.options.autosave.submit_delay || easyMDE.options.autosave.delay || 10000);
-                    }
                 });
             }
 
@@ -2127,12 +2116,6 @@ EasyMDE.prototype.autosave = function (repeatSaving) {
             var save = this.options.autosave.text == undefined ? 'Autosaved: ' : this.options.autosave.text;
 
             el.innerHTML = save + dd;
-        }
-
-        if (repeatSaving === true) {
-           this.autosaveTimeoutId = setTimeout(function () {
-                easyMDE.autosave(repeatSaving);
-            }, this.options.autosave.delay || 10000);
         }
     } else {
         console.log('EasyMDE: localStorage not available, cannot autosave');


### PR DESCRIPTION
Fix #181 

The solution would be to have an option that allows you to make the save when you modify the text of the current easymde instance.