### PR TITLE
option for setting html into preview

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -936,7 +936,7 @@ function toggleSideBySide(editor) {
     var sideBySideRenderingFunction = function () {
         var newValue = editor.options.previewRender(editor.value(), preview);
         if (newValue != null) {
-            preview.innerHTML = newValue;
+            editor.options.setPreviewRender(preview, newValue);
         }
     };
 
@@ -947,7 +947,7 @@ function toggleSideBySide(editor) {
     if (useSideBySideListener) {
         var newValue = editor.options.previewRender(editor.value(), preview);
         if (newValue != null) {
-            preview.innerHTML = newValue;
+            editor.options.setPreviewRender(preview, newValue);
         }
         cm.on('update', cm.sideBySideRenderingFunction);
     } else {
@@ -1014,8 +1014,7 @@ function togglePreview(editor) {
             toolbar_div.className += ' disabled-for-preview';
         }
     }
-    preview.innerHTML = editor.options.previewRender(editor.value(), preview);
-
+    editor.options.setPreviewRender(preview, editor.options.previewRender(editor.value(), preview));
 }
 
 function _replaceSelection(cm, active, startEnd, url) {
@@ -1688,6 +1687,12 @@ function EasyMDE(options) {
             // Note: "this" refers to the options object
             return this.parent.markdown(plainText);
         };
+    }
+
+    if (!options.setPreviewRender) {
+      options.setPreviewRender = function (preview, html) {
+        preview.innerHTML = html;
+      };
     }
 
 
@@ -2609,7 +2614,7 @@ EasyMDE.prototype.value = function (val) {
         if (this.isPreviewActive()) {
             var wrapper = cm.getWrapperElement();
             var preview = wrapper.lastChild;
-            preview.innerHTML = this.options.previewRender(val, preview);
+            this.options.setPreviewRender(preview, this.options.previewRender(val, preview));
         }
         return this;
     }


### PR DESCRIPTION
This PR adds an option to set the preview html. Currently, we use `preview.innerHTML = html` which is still the default. Now we allow users to render the html differently into the dom.

My use-case is that setting `innerHTML` leads to flickering when an image is inside the preview. This way, I can now use `html-to-react` for the generated html and then render with react - which does the diffing for me. Maybe not a perfect solution, but for me this works much better now.