### PR TITLE
Fix calls to updateStatusBar when the status bar is hidden

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1849,6 +1849,10 @@ EasyMDE.prototype.uploadImagesUsingCustomFunction = function (imageUploadFunctio
  * @param content {string} the new content of the item to write in the status bar.
  */
 EasyMDE.prototype.updateStatusBar = function (itemName, content) {
+    if (!this.gui.statusbar) {
+        return;
+    }
+
     var matchingClasses = this.gui.statusbar.getElementsByClassName(itemName);
     if (matchingClasses.length === 1) {
         this.gui.statusbar.getElementsByClassName(itemName)[0].textContent = content;


### PR DESCRIPTION
For example:

```js
var easyMDE = new EasyMDE({
    status: false,
    uploadImage: true
});
```

and when an image is attempted to be uploaded, the console logs:
`Uncaught TypeError: Cannot read property 'getElementsByClassName' of undefined`

Caused by: https://github.com/Ionaru/easy-markdown-editor/blob/754bdc3ab27236f426d62fb0b9894c77f50f6d87/src/js/easymde.js#L1852 as`this.gui.statusbar` is `undefined` when the bar is hidden.