### PR TITLE
Pass the MDE context to the custom image function

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2287,7 +2287,7 @@ EasyMDE.prototype.uploadImageUsingCustomFunction = function(imageUploadFunction,
             .replace('#image_max_size#', humanFileSize(self.options.imageMaxSize, units));
     }
 
-    imageUploadFunction(file, onSuccess, onError);
+    imageUploadFunction.apply(this, [file, onSuccess, onError]);
 };
 
 EasyMDE.prototype.setPreviewMaxHeight = function () {


### PR DESCRIPTION
Removes the need to bind the context manually to the `imageUploadFunction` when wanting to access the class methods (such as `this.updateStatusBar`).