### PR TITLE
include codemirror autorefresh addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **uniqueId**: You must set a unique string identifier so that EasyMDE can autosave. Something that separates this from other instances of EasyMDE elsewhere on your website.
   - **timeFormat**: Set DateTimeFormat. More information see [DateTimeFormat instances](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat). Default `locale: en-US, format: hour:minute`.
   - **text**: Set text for autosave.
+- **autoRefresh**: Useful, when initializing the editor in a hidden DOM node. If set to `{ delay: 300 }`, it will check every 300 ms if the editor is visible and if positive, call CodeMirror's [`refresh()`](https://codemirror.net/doc/manual.html#refresh).
 - **blockStyles**: Customize how certain buttons that style blocks of text behave.
   - **bold**: Can be set to `**` or `__`. Defaults to `**`.
   - **code**: Can be set to  ```` ``` ```` or `~~~`.  Defaults to ```` ``` ````.

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -6,6 +6,7 @@ require('codemirror/addon/display/fullscreen.js');
 require('codemirror/mode/markdown/markdown.js');
 require('codemirror/addon/mode/overlay.js');
 require('codemirror/addon/display/placeholder.js');
+require('codemirror/addon/display/autorefresh.js');
 require('codemirror/addon/selection/mark-selection.js');
 require('codemirror/addon/search/searchcursor.js');
 require('codemirror/mode/gfm/gfm.js');
@@ -2043,6 +2044,7 @@ EasyMDE.prototype.render = function (el) {
         configureMouse: configureMouse,
         inputStyle: (options.inputStyle != undefined) ? options.inputStyle : isMobile() ? 'contenteditable' : 'textarea',
         spellcheck: (options.nativeSpellcheck != undefined) ? options.nativeSpellcheck : true,
+        autoRefresh: (options.autoRefresh != undefined) ? options.autoRefresh : false,
     });
 
     this.codemirror.getScrollerElement().style.minHeight = options.minHeight;

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -168,6 +168,7 @@ declare namespace EasyMDE {
         autoDownloadFontAwesome?: boolean;
         autofocus?: boolean;
         autosave?: AutoSaveOptions;
+        autoRefresh?: boolean | { delay: number };
         blockStyles?: BlockStyleOptions;
         element?: HTMLElement;
         forceSync?: boolean;


### PR DESCRIPTION
I got this problem, that when rendering easyMDE in a hidden tab, I need to click inside the editor before seeing what content is inside it.
It's a known problem: 
- CodeMirror issue https://github.com/codemirror/CodeMirror/issues/2469
- EasyMDE issue #84 

Including the Codemirror AutoRefresh addon solves it.
I added the option `autoRefresh` as well and included the Typescript typings.

To use it, add the option:
`autoRefresh: { delay: 250 },`