### PR TITLE
Expose the CodeMirror library object, so static methods like defineExtension can be called on it

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2863,4 +2863,6 @@ EasyMDE.prototype.toTextArea = function () {
     }
 };
 
+EasyMDE.CodeMirror = CodeMirror;
+
 module.exports = EasyMDE;


### PR DESCRIPTION
Hi,

This is a very small change to enable more customization of EasyMDE/CodeMirror, like allowing addons to be used (fixes [#188] then).  Otherwise there is no way to run [CodeMirror static methods](https://codemirror.net/doc/manual.html#api_static).

It is very similar to [#76] but more cautious (not setting global `window.CodeMirror`).
In that pull request it was suggested to just package another copy of CodeMirror, but that doesn't work because running `CodeMirror.defineExtension(...)` would only affect the separate copy and not the one used by EasyMDE.

Steps to enable a CodeMirror addon would be:
* include `easymde.min.js` on page as usual
* `EasyMDE.CodeMirror.defineExtension(...)`
* or if you want to use a standard addon: `window.CodeMirror = EasyMDE.CodeMirror` and include the addon .js file