### PR TITLE
Fix the sideBySideFullscreen=false + status=false bug

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -883,9 +883,11 @@ function toggleSideBySide(editor) {
     }
 
     function removeNoFullscreenClass(el) {
-        el.className = el.className.replace(
-            /\s*sided--no-fullscreen\s*/g, ''
-        );
+        if (el != null) {
+            el.className = el.className.replace(
+                /\s*sided--no-fullscreen\s*/g, ''
+            );
+        }
     }
 
     if (/editor-preview-active-side/.test(preview.className)) {
@@ -909,9 +911,9 @@ function toggleSideBySide(editor) {
                 if (editor.options.sideBySideFullscreen === false) {
                     cm.setOption('sideBySideNoFullscreen', true);
                     noFullscreenItems.forEach(function(el) {
-                        if (el) {
+                        if (el != null) {
                             addNoFullscreenClass(el);
-                        };
+                        }
                     });
                 } else {
                     toggleFullScreen(editor);

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -909,7 +909,9 @@ function toggleSideBySide(editor) {
                 if (editor.options.sideBySideFullscreen === false) {
                     cm.setOption('sideBySideNoFullscreen', true);
                     noFullscreenItems.forEach(function(el) {
-                        addNoFullscreenClass(el);
+                        if (el) {
+                            addNoFullscreenClass(el);
+                        };
                     });
                 } else {
                     toggleFullScreen(editor);
@@ -2142,7 +2144,7 @@ EasyMDE.prototype.render = function (el) {
                         assignImageBlockAttributes(parentEl, window.EMDEimagesCache[keySrc]);
                     }
                 }
-            } 
+            }
         });
     }
     this.codemirror.on('update', function () {


### PR DESCRIPTION
This pull request fixes the `Cannot read property 'className' of undefined` bug when the `sideBySideFullscreen` and `status` are both set to `false`.