### PR TITLE
Drag and drop a file checks the extension to either create an image or link

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -811,7 +811,17 @@ function afterImageUploaded(editor, url) {
     var stat = getState(cm);
     var options = editor.options;
     var imageName = url.substr(url.lastIndexOf('/') + 1);
-    _replaceSelection(cm, stat.image, options.insertTexts.uploadedImage, url);
+    var ext = imageName.substring(imageName.lastIndexOf('.') + 1);
+
+    // Check if media is an image
+    if (['png', 'jpg', 'jpeg', 'gif', 'svg'].includes(ext)) {
+      _replaceSelection(cm, stat.image, options.insertTexts.uploadedImage, url);
+    } else {
+      var text_link = options.insertTexts.link;
+      text_link[0] = '[' + imageName;
+      _replaceSelection(cm, stat.link, text_link, url);
+    }
+
     // show uploaded image filename for 1000ms
     editor.updateStatusBar('upload-image', editor.options.imageTexts.sbOnUploaded.replace('#image_name#', imageName));
     setTimeout(function () {


### PR DESCRIPTION
Related to issue #269

Example, if you were to drag and drop a PDF, it would show as an image and therefore not display anything.
Non-image files should create a markdown link instead.

With these changes, only the following extensions will create an image link : 

- png
- jpg
- jpeg
- gif
- svg

This is my first time creating a pull request, please let me know if anything is missing.

Thank you!