### PR TITLE
Use visibility:hidden; instead of display:none; for the dropdown menu

### DIFF
--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -360,7 +360,8 @@
 }
 
 .easymde-dropdown-content {
-    display: none;
+    display: block;
+    visibility: hidden;
     position: absolute;
     background-color: #f9f9f9;
     box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
@@ -371,7 +372,7 @@
 
 .easymde-dropdown:active .easymde-dropdown-content,
 .easymde-dropdown:focus .easymde-dropdown-content {
-    display: block;
+    visibility: visible;
 }
 
 span[data-img-src]::after{


### PR DESCRIPTION
Currently, buttons within a dropdown menu (`.easymde-dropdown-content`) do not always work. I think that with `display: none;` when the dropdown menu button (`.easymde-dropdown`) loses focus, click events of the buttons within the dropdown menu are not necessarily propagated.

Replacing `display: none;` with `visibility: hidden;` solves the problem.