### PR TITLE
don't toggle preview if sideBySideFullscreen is false

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -332,11 +332,12 @@ function toggleFullScreen(editor) {
         document.body.style.overflow = saved_overflow;
     }
 
-
-    // Hide side by side if needed
-    var sidebyside = cm.getWrapperElement().nextSibling;
-    if (/editor-preview-active-side/.test(sidebyside.className))
-        toggleSideBySide(editor);
+    // Hide side by side if needed, retain current state if sideBySideFullscreen is disabled
+    if (editor.options.sideBySideFullscreen !== false) {
+        var sidebyside = cm.getWrapperElement().nextSibling;
+        if (/editor-preview-active-side/.test(sidebyside.className))
+            toggleSideBySide(editor);
+    }
 
     if (editor.options.onToggleFullScreen) {
         editor.options.onToggleFullScreen(cm.getOption('fullScreen') || false);


### PR DESCRIPTION
Toggling fullscreen causes the enabled side-by-side preview to be hidden when `sideBySideFullscreen === false`.  This change causes the editor to ignore the preview state when the default "side-by-side requires fullscreen" option is disabled.

(Long story: default behavior was to trigger full screen when enabling side-by-side preview, an option was added to allow for side-by-side preview without full screen, but didn't account for existing side-by-side handling when toggling fullscreen, which was [apparently] intended to ensure it was toggled off when returning from fullscreen.)