### PR TITLE
Fixed extension acquisition logic

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -812,7 +812,7 @@ function afterImageUploaded(editor, url) {
     var stat = getState(cm);
     var options = editor.options;
     var imageName = url.substr(url.lastIndexOf('/') + 1);
-    var ext = imageName.substring(imageName.lastIndexOf('.') + 1);
+    var ext = imageName.substring(imageName.lastIndexOf('.') + 1).replace(/\?.*$/, '');
 
     // Check if media is an image
     if (['png', 'jpg', 'jpeg', 'gif', 'svg'].includes(ext)) {


### PR DESCRIPTION
## Issue

When inserting an image URL with query parameters, it is displayed as a link.
(When using imageUploadFunction)

```
https://image.png?alt=media
```

to

```
[](https://image.png?alt=media)
```

## Solution

Remove query parameters from extension