### PR TITLE
Absolute image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ easyMDE.value('New input for **EasyMDE**');
 - **imageUploadFunction**: A custom function for handling the image upload. Using this function will render the options `imageMaxSize`, `imageAccept`, `imageUploadEndpoint` and `imageCSRFToken` ineffective.
     - The function gets a file and onSuccess and onError callback functions as parameters. `onSuccess(imageUrl: string)` and `onError(errorMessage: string)`
 - **imageUploadEndpoint**: The endpoint where the images data will be sent, via an asynchronous *POST* request. The server is supposed to save this image, and return a json response.
-     - if the request was successfully processed (HTTP 200-OK): `{"data": {"filePath": "<filePath>"}}` where *filePath* is the relative path of the image;
+     - if the request was successfully processed (HTTP 200-OK): `{"data": {"filePath": "<filePath>"}}` where *filePath* is the path of the image (absolute if `imagePathAbsolute` is set to true, relative if otherwise);
      - otherwise: `{"error": "<errorCode>"}`, where *errorCode* can be `noFileGiven` (HTTP 400), `typeNotAllowed` (HTTP 415), `fileTooLarge` (HTTP 413) or `importError` (see *errorMessages* below). If *errorCode* is not one of the *errorMessages*, it is alerted unchanged to the user. This allows for server side error messages.
      No default value.
+- **imagePathAbsolute**: If set to `true`, will treat `imageUrl` from `imageUploadFunction` and *filePath* returned from `imageUploadEndpoint` as an absolute rather than relative path, i.e. not prepend `window.location.origin` to it.
 - **imageCSRFToken**: CSRF token to include with AJAX call to upload image. For instance used with Django backend.
 - **imageTexts**: Texts displayed to the user (mainly on the status bar) for the import image feature, where `#image_name#`, `#image_size#` and `#image_max_size#` will replaced by their respective values, that can be used for customization or internationalization:
     - **sbInit**: Status message displayed initially if `uploadImage` is set to `true`. Defaults to `Attach files by drag and dropping or pasting from clipboard.`.

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2340,7 +2340,7 @@ EasyMDE.prototype.uploadImage = function (file, onSuccess, onError) {
             return;
         }
         if (this.status === 200 && response && !response.error && response.data && response.data.filePath) {
-            onSuccess(window.location.origin + '/' + response.data.filePath);
+            onSuccess((self.options.imagePathAbsolute ? '' : (window.location.origin + '/')) + response.data.filePath);
         } else {
             if (response.error && response.error in self.options.errorMessages) {  // preformatted error message
                 onErrorSup(fillErrorMessage(self.options.errorMessages[response.error]));

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -207,6 +207,7 @@ declare namespace EasyMDE {
         imageAccept?: string;
         imageUploadFunction?: (file: File, onSuccess: (url: string) => void, onError: (error: string) => void) => void;
         imageUploadEndpoint?: string;
+        imagePathAbsolute?: boolean;
         imageCSRFToken?: string;
         imageTexts?: ImageTextsOptions;
         errorMessages?: ImageErrorTextsOptions;


### PR DESCRIPTION
Adds an option `imageAbsolutePath` that, if set to true, treats the image path returned by `imageUploadEndpoint` or `imageUploadFunction` as an absolute path rather than relative path (doesn't append `window.location.origin` to it). Solves #305 