### PR TITLE
Bugfix: Correctly keep preview active during fullscreen-toggle

### DIFF
--- a/example/index_sideBySideFullscreenFalse.html
+++ b/example/index_sideBySideFullscreenFalse.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Example / Preview / sideBySideFullscreen : true</title>
+    <link rel="stylesheet" href="../dist/easymde.min.css">
+    <script src="../dist/easymde.min.js"></script>
+</head>
+
+<body>
+    <textarea></textarea>
+    <script>
+        var easyMDE = new EasyMDE({sideBySideFullscreen: false});
+    </script>
+</body>
+
+</html>

--- a/example/index_sideBySideFullscreenFalse.html
+++ b/example/index_sideBySideFullscreenFalse.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Example / Preview / sideBySideFullscreen : true</title>
+    <title>Example / Preview / sideBySideFullscreen : false</title>
     <link rel="stylesheet" href="../dist/easymde.min.css">
     <script src="../dist/easymde.min.js"></script>
 </head>

--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -41,7 +41,7 @@
     width: 50% !important;
 }
 
-.EasyMDEContainer .CodeMirror-sided.sided--no-fullscreen {
+.EasyMDEContainer.sided--no-fullscreen .CodeMirror-sided {
     border-right: none!important;
     border-bottom-right-radius: 0px;
     position: relative;
@@ -118,7 +118,7 @@
     padding: 0;
 }
 
-.editor-toolbar.sided--no-fullscreen {
+.EasyMDEContainer.sided--no-fullscreen .editor-toolbar {
     width: 100%;
 }
 
@@ -201,7 +201,7 @@
     text-align: right;
 }
 
-.editor-statusbar.sided--no-fullscreen {
+.EasyMDEContainer.sided--no-fullscreen .editor-statusbar {
     width: 100%;
 }
 
@@ -253,7 +253,7 @@
     display: block
 }
 
-.editor-preview-active-side.sided--no-fullscreen {
+.EasyMDEContainer.sided--no-fullscreen .editor-preview-active-side {
     flex: 1 1 auto;
     height: auto;
     position: static;

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -923,6 +923,7 @@ function toggleSideBySide(editor) {
         useSideBySideListener = true;
     }
 
+    // Hide normal preview if active
     var previewNormal = wrapper.lastChild;
     if (/editor-preview-active/.test(previewNormal.className)) {
         previewNormal.className = previewNormal.className.replace(

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -973,7 +973,8 @@ function toggleSideBySide(editor, onlyCleanup) {
 
 
 /**
- * Preview action.
+ * Toggle display of normal (full-pane) preview.
+ * @param {EasyMDE} editor - The EasyMDE object
  */
 function togglePreview(editor) {
     var cm = editor.codemirror;
@@ -982,12 +983,12 @@ function togglePreview(editor) {
     var toolbar = editor.options.toolbar ? editor.toolbarElements.preview : false;
     var preview = wrapper.lastChild;
 
-    // Turn off side by side if needed
+    // Turn off side by side, if needed
     var sidebyside = cm.getWrapperElement().nextSibling;
     if (/editor-preview-active-side/.test(sidebyside.className))
         toggleSideBySide(editor);
 
-    // Construct preview element if it doesn't exist
+    // Construct normal (full-pane) preview element if it doesn't exist
     if (!preview || !/editor-preview-full/.test(preview.className)) {
 
         preview = document.createElement('div');
@@ -1008,7 +1009,7 @@ function togglePreview(editor) {
         wrapper.appendChild(preview);
     }
 
-    // Toggle display of preview depending on current state
+    // Toggle display of normal (full-pane) preview depending on current state
     if (/editor-preview-active/.test(preview.className)) {
         preview.className = preview.className.replace(
             /\s*editor-preview-active\s*/g, ''

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -880,9 +880,9 @@ function redo(editor) {
     cm.focus();
 }
 
+
 /**
  * Toggle side by side preview
- * @param {EasyMDE} editor - The EasyMDE object
  */
 function toggleSideBySide(editor) {
     var cm = editor.codemirror;
@@ -962,8 +962,7 @@ function toggleSideBySide(editor) {
 
 
 /**
- * Toggle display of normal (full-pane) preview.
- * @param {EasyMDE} editor - The EasyMDE object
+ * Preview action.
  */
 function togglePreview(editor) {
     var cm = editor.codemirror;
@@ -972,12 +971,11 @@ function togglePreview(editor) {
     var toolbar = editor.options.toolbar ? editor.toolbarElements.preview : false;
     var preview = wrapper.lastChild;
 
-    // Turn off side by side, if needed
+    // Turn off side by side if needed
     var sidebyside = cm.getWrapperElement().nextSibling;
     if (/editor-preview-active-side/.test(sidebyside.className))
         toggleSideBySide(editor);
 
-    // Construct normal (full-pane) preview element if it doesn't exist
     if (!preview || !/editor-preview-full/.test(preview.className)) {
 
         preview = document.createElement('div');
@@ -998,7 +996,6 @@ function togglePreview(editor) {
         wrapper.appendChild(preview);
     }
 
-    // Toggle display of normal (full-pane) preview depending on current state
     if (/editor-preview-active/.test(preview.className)) {
         preview.className = preview.className.replace(
             /\s*editor-preview-active\s*/g, ''

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -323,6 +323,7 @@ function toggleFullScreen(editor) {
     var cm = editor.codemirror;
     cm.setOption('fullScreen', !cm.getOption('fullScreen'));
 
+
     // Prevent scrolling on body during fullscreen active
     if (cm.getOption('fullScreen')) {
         saved_overflow = document.body.style.overflow;
@@ -873,7 +874,7 @@ function redo(editor) {
 
 
 /**
- * Toggle side by side preview.
+ * Toggle side by side preview
  * @param {EasyMDE} editor - The EasyMDE object
  * @param {boolean} onlyCleanup Flag for only cleaning up side effects of fullScreen toggle.
  */
@@ -932,7 +933,6 @@ function toggleSideBySide(editor, onlyCleanup) {
         wrapper.className += ' CodeMirror-sided';
         useSideBySideListener = true;
     }
-    
 
     // Hide normal (full-pane) preview if active
     var previewNormal = wrapper.lastChild;
@@ -989,6 +989,7 @@ function togglePreview(editor) {
 
     // Construct preview element if it doesn't exist
     if (!preview || !/editor-preview-full/.test(preview.className)) {
+
         preview = document.createElement('div');
         preview.className = 'editor-preview-full';
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -336,7 +336,8 @@ function toggleFullScreen(editor) {
     var sidebyside = wrapper.nextSibling;
 
     if (/editor-preview-active-side/.test(sidebyside.className)) {
-        if(editor.options.sideBySideFullscreen === false) {
+        if (editor.options.sideBySideFullscreen === false) {
+            // if side-by-side not-fullscreen ok, apply classes as needed
             var easyMDEContainer = wrapper.parentNode;
             if (cm.getOption('fullScreen')) {
                 easyMDEContainer.className = easyMDEContainer.className.replace(/\s*sided--no-fullscreen(\s*)/g, '$1');
@@ -893,8 +894,8 @@ function toggleSideBySide(editor) {
     var easyMDEContainer = wrapper.parentNode;
 
     if (/editor-preview-active-side/.test(preview.className)) {
-        // close side-by-side, and cleanup noFullscreen classes as needed
         if (editor.options.sideBySideFullscreen === false) {
+            // if side-by-side not-fullscreen ok, remove classes when hiding side
             easyMDEContainer.className = easyMDEContainer.className.replace(/\s*sided--no-fullscreen(\s*)/g, '$1');
         }
         preview.className = preview.className.replace(
@@ -909,6 +910,7 @@ function toggleSideBySide(editor) {
         setTimeout(function () {
             if (!cm.getOption('fullScreen')) {
                 if (editor.options.sideBySideFullscreen === false) {
+                    // if side-by-side not-fullscreen ok, add classes when not fullscreen and showing side
                     easyMDEContainer.className += ' sided--no-fullscreen';
                 } else {
                     toggleFullScreen(editor);

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -935,11 +935,10 @@ function toggleSideBySide(editor, onlyCleanup) {
         wrapper.className = wrapper.className.replace(/\s*CodeMirror-sided\s*/g, ' ');
     } else {
         // open side-by-side, and setup noFullscreen classes as needed
+        // When the preview button is clicked for the first time,
+        // give some time for the transition from editor.css to fire and the view to slide from right to left,
+        // instead of just appearing.
         setTimeout(function () {
-            // When the preview button is clicked for the first time,
-            // give some time for the transition from editor.css to 
-            // fire and the view to slide from right to left,
-            // instead of just appearing.
             if (!cm.getOption('fullScreen')) {
                 if (editor.options.sideBySideFullscreen === false) {
                     setupNoFullscreenClasses(true);

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -911,59 +911,49 @@ function toggleSideBySide(editor, triggeredByFullscreenToggle) {
     }
 
     // helper method to add/remove no-fullscreen classes as appropriate
-    function setupNoFullscreenClasses(previewActive) {
+    function setupNoFullscreenClasses(sidePreviewActive) {
         if (editor.options.sideBySideFullscreen === false) {
-            if (!cm.getOption('fullScreen') && previewActive) {
-                noFullscreenItems.forEach(function(el) {
-                    addNoFullscreenClass(el);
-                });
+            if (!cm.getOption('fullScreen') && sidePreviewActive) {
+                // only apply classes if !fullScreen and side preview is (or will be) active
+                noFullscreenItems.forEach(addNoFullscreenClass);
             } else {
-                noFullscreenItems.forEach(function (el) {
-                    removeNoFullscreenClass(el);
-                });
+                noFullscreenItems.forEach(removeNoFullscreenClass);
             }
         }
     }
 
-    if (/editor-preview-active-side/.test(preview.className)) {
-        // If side-by-side active...
-        if (dontToggle) {
-            // if not toggling, cleanup noFullscreen classes as needed
-            setupNoFullscreenClasses(true);
-        } else {
-            // otherwise close side-by-side, and cleanup noFullscreen classes as needed
-            setupNoFullscreenClasses(false);
-            preview.className = preview.className.replace(
-                /\s*editor-preview-active-side\s*/g, ''
-            );
-            if (toolbarButton) toolbarButton.className = toolbarButton.className.replace(/\s*active\s*/g, '');
-            wrapper.className = wrapper.className.replace(/\s*CodeMirror-sided\s*/g, ' ');
-        }
+    var sidePreviewActive = /editor-preview-active-side/.test(preview.className);
+
+    if (dontToggle) {
+        // if not toggling, handle noFullscreen classes as needed
+        setupNoFullscreenClasses(sidePreviewActive);
+    } else if (sidePreviewActive) {
+        // close side-by-side, and cleanup noFullscreen classes as needed
+        setupNoFullscreenClasses(false);
+        preview.className = preview.className.replace(
+            /\s*editor-preview-active-side\s*/g, ''
+        );
+        if (toolbarButton) toolbarButton.className = toolbarButton.className.replace(/\s*active\s*/g, '');
+        wrapper.className = wrapper.className.replace(/\s*CodeMirror-sided\s*/g, ' ');
     } else {
-        // If side-by-side not active...
-        if (dontToggle) {
-            // if not toggling, cleanup noFullscreen classes as needed
-            setupNoFullscreenClasses(false);
-        } else {
-            // otherwise open side-by-side, and setup noFullscreen classes as needed
-            setTimeout(function () {
-                // When the preview button is clicked for the first time,
-                // give some time for the transition from editor.css to 
-                // fire and the view to slide from right to left,
-                // instead of just appearing.
-                if (!cm.getOption('fullScreen')) {
-                    if (editor.options.sideBySideFullscreen === false) {
-                        setupNoFullscreenClasses(true);
-                    } else {
-                        toggleFullScreen(editor);
-                    }
+        // open side-by-side, and setup noFullscreen classes as needed
+        setTimeout(function () {
+            // When the preview button is clicked for the first time,
+            // give some time for the transition from editor.css to 
+            // fire and the view to slide from right to left,
+            // instead of just appearing.
+            if (!cm.getOption('fullScreen')) {
+                if (editor.options.sideBySideFullscreen === false) {
+                    setupNoFullscreenClasses(true);
+                } else {
+                    toggleFullScreen(editor);
                 }
-                preview.className += ' editor-preview-active-side';
-            }, 1);
-            if (toolbarButton) toolbarButton.className += ' active';
-            wrapper.className += ' CodeMirror-sided';
-            useSideBySideListener = true;
-        }
+            }
+            preview.className += ' editor-preview-active-side';
+        }, 1);
+        if (toolbarButton) toolbarButton.className += ' active';
+        wrapper.className += ' CodeMirror-sided';
+        useSideBySideListener = true;
     }
     
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -139,6 +139,50 @@ function fixShortcut(name) {
 }
 
 /**
+ * Class handling utility methods.
+ */
+var CLASS_REGEX = {};
+
+/**
+ * Convert a className string into a regex for matching (and cache).
+ * Note that the RegExp includes trailing spaces for replacement
+ * (to ensure that removing a class from the middle of the string will retain
+ *  spacing between other classes.)
+ * @param {String} className Class name to convert to regex for matching.
+ * @returns {RegExp} Regular expression option that will match className.
+ */
+function getClassRegex (className) {
+    return CLASS_REGEX[className] || (CLASS_REGEX[className] = new RegExp('\\s*' + className + '(\\s*)', 'g'));
+}
+
+/**
+ * Add a class string to an element.
+ * @param {Element} el DOM element on which to add className.
+ * @param {String} className Class string to apply
+ * @returns {void}
+ */
+function addClass (el, className) {
+    if (!el || !className) return;
+    var classRegex = getClassRegex(className);
+    if (el.className.match(classRegex)) return; // already applied
+    el.className += ' ' + className;
+}
+
+/**
+ * Remove a class string from an element.
+ * @param {Element} el DOM element from which to remove className.
+ * @param {String} className Class string to remove
+ * @returns {void}
+ */
+ function removeClass (el, className) {
+    if (!el || !className) return;
+    var classRegex = getClassRegex(className);
+    if (!el.className.match(classRegex)) return; // not available to remove
+    el.className = el.className.replace(classRegex, '$1');
+}
+
+
+/**
  * Create dropdown block
  */
 function createToolbarDropdown(options, enableTooltips, shortcuts, parent) {
@@ -340,9 +384,9 @@ function toggleFullScreen(editor) {
             // if side-by-side not-fullscreen ok, apply classes as needed
             var easyMDEContainer = wrapper.parentNode;
             if (cm.getOption('fullScreen')) {
-                easyMDEContainer.className = easyMDEContainer.className.replace(/\s*sided--no-fullscreen(\s*)/g, '$1');
+                removeClass(easyMDEContainer, 'sided--no-fullscreen');
             } else {
-                easyMDEContainer.className += ' sided--no-fullscreen';
+                addClass(easyMDEContainer, 'sided--no-fullscreen');
             }
         } else {
             toggleSideBySide(editor);
@@ -896,7 +940,7 @@ function toggleSideBySide(editor) {
     if (/editor-preview-active-side/.test(preview.className)) {
         if (editor.options.sideBySideFullscreen === false) {
             // if side-by-side not-fullscreen ok, remove classes when hiding side
-            easyMDEContainer.className = easyMDEContainer.className.replace(/\s*sided--no-fullscreen(\s*)/g, '$1');
+            removeClass(easyMDEContainer, 'sided--no-fullscreen');
         }
         preview.className = preview.className.replace(
             /\s*editor-preview-active-side\s*/g, ''
@@ -911,7 +955,7 @@ function toggleSideBySide(editor) {
             if (!cm.getOption('fullScreen')) {
                 if (editor.options.sideBySideFullscreen === false) {
                     // if side-by-side not-fullscreen ok, add classes when not fullscreen and showing side
-                    easyMDEContainer.className += ' sided--no-fullscreen';
+                    addClass(easyMDEContainer, 'sided--no-fullscreen');
                 } else {
                     toggleFullScreen(editor);
                 }

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -333,9 +333,12 @@ function toggleFullScreen(editor) {
 
     var sidebyside = cm.getWrapperElement().nextSibling;
 
-    // if (/editor-preview-active-side/.test(sidebyside.className)) {
-        toggleSideBySide(editor, true);
-    // }
+    // if non-fullscreen side-by-side is allowed, then pass along "dontToggle" flag
+    var dontToggleSideBySide = editor.options.sideBySideFullscreen === false;
+
+    if (/editor-preview-active-side/.test(sidebyside.className) || dontToggleSideBySide) {
+        toggleSideBySide(editor, dontToggleSideBySide);
+    }
 
     if (editor.options.onToggleFullScreen) {
         editor.options.onToggleFullScreen(cm.getOption('fullScreen') || false);
@@ -871,20 +874,15 @@ function redo(editor) {
 
 /**
  * Toggle side by side preview.
- * Note: If triggered by fullscreen toggle and sideBySideFullscreen === false,
- *       `sideBySide` is not actually toggled, but classes are reapplied as needed.
  * @param {EasyMDE} editor - The EasyMDE object
- * @param {boolean} triggeredByFullscreenToggle If triggered by fullscreen toggle.
+ * @param {boolean} dontToggle Flag for cleaning up side effects of fullScreen toggle.
  */
-function toggleSideBySide(editor, triggeredByFullscreenToggle) {
+function toggleSideBySide(editor, dontToggle) {
     var cm = editor.codemirror;
     var wrapper = cm.getWrapperElement();
     var preview = wrapper.nextSibling;
     var toolbarButton = editor.toolbarElements && editor.toolbarElements['side-by-side'];
     var useSideBySideListener = false;
-
-    // if triggered by fullscreen toggle and sideBySideFullscreen === false, don't toggle
-    var dontToggle = editor.options.sideBySideFullscreen === false && triggeredByFullscreenToggle;
 
     var noFullscreenItems = [
         wrapper.parentNode, // easyMDEContainer

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -332,9 +332,10 @@ function toggleFullScreen(editor) {
         document.body.style.overflow = saved_overflow;
     }
 
+    var sidebyside = cm.getWrapperElement().nextSibling;
+
     // Hide side by side if needed, retain current state if sideBySideFullscreen is disabled
     if (editor.options.sideBySideFullscreen !== false) {
-        var sidebyside = cm.getWrapperElement().nextSibling;
         if (/editor-preview-active-side/.test(sidebyside.className))
             toggleSideBySide(editor);
     }

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -333,11 +333,11 @@ function toggleFullScreen(editor) {
 
     var sidebyside = cm.getWrapperElement().nextSibling;
 
-    // if non-fullscreen side-by-side is allowed, then pass along "dontToggle" flag
-    var dontToggleSideBySide = editor.options.sideBySideFullscreen === false;
+    // if non-fullscreen side-by-side is allowed, then pass along "onlyCleanup" flag
+    var onlyCleanup = editor.options.sideBySideFullscreen === false;
 
-    if (/editor-preview-active-side/.test(sidebyside.className) || dontToggleSideBySide) {
-        toggleSideBySide(editor, dontToggleSideBySide);
+    if (/editor-preview-active-side/.test(sidebyside.className) || onlyCleanup) {
+        toggleSideBySide(editor, onlyCleanup);
     }
 
     if (editor.options.onToggleFullScreen) {
@@ -875,9 +875,9 @@ function redo(editor) {
 /**
  * Toggle side by side preview.
  * @param {EasyMDE} editor - The EasyMDE object
- * @param {boolean} dontToggle Flag for cleaning up side effects of fullScreen toggle.
+ * @param {boolean} onlyCleanup Flag for only cleaning up side effects of fullScreen toggle.
  */
-function toggleSideBySide(editor, dontToggle) {
+function toggleSideBySide(editor, onlyCleanup) {
     var cm = editor.codemirror;
     var wrapper = cm.getWrapperElement();
     var preview = wrapper.nextSibling;
@@ -922,7 +922,7 @@ function toggleSideBySide(editor, dontToggle) {
 
     var sidePreviewActive = /editor-preview-active-side/.test(preview.className);
 
-    if (dontToggle) {
+    if (onlyCleanup) {
         // if not toggling, handle noFullscreen classes as needed
         setupNoFullscreenClasses(sidePreviewActive);
     } else if (sidePreviewActive) {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -923,7 +923,6 @@ function toggleSideBySide(editor) {
         useSideBySideListener = true;
     }
 
-    // Hide normal (full-pane) preview if active
     var previewNormal = wrapper.lastChild;
     if (/editor-preview-active/.test(previewNormal.className)) {
         previewNormal.className = previewNormal.className.replace(

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -884,38 +884,18 @@ function toggleSideBySide(editor, onlyCleanup) {
     var toolbarButton = editor.toolbarElements && editor.toolbarElements['side-by-side'];
     var useSideBySideListener = false;
 
-    var noFullscreenItems = [
-        wrapper.parentNode, // easyMDEContainer
-        editor.gui.toolbar,
-        wrapper,
-        preview,
-        editor.gui.statusbar,
-    ];
-
-    function addNoFullscreenClass(el) {
-        if (el != null) {
-            el.className += ' sided--no-fullscreen';
-        }
-    }
-
-    function removeNoFullscreenClass(el) {
-        if (el != null) {
-            el.className = el.className.replace(
-                // retain spaces after the class
-                // in case there are subsequent classes
-                /\s*sided--no-fullscreen(\s*)/g, '$1'
-            );
-        }
-    }
+    var easyMDEContainer = wrapper.parentNode;
 
     // helper method to add/remove no-fullscreen classes as appropriate
-    function setupNoFullscreenClasses(sidePreviewActive) {
+    function setNoFullscreenClass (sidePreviewActive) {
         if (editor.options.sideBySideFullscreen === false) {
             if (!cm.getOption('fullScreen') && sidePreviewActive) {
+                easyMDEContainer.className += ' sided--no-fullscreen';
                 // only apply classes if !fullScreen and side preview is (or will be) active
-                noFullscreenItems.forEach(addNoFullscreenClass);
             } else {
-                noFullscreenItems.forEach(removeNoFullscreenClass);
+                // retain spaces after the class
+                // in case there are subsequent classes
+                easyMDEContainer.className = easyMDEContainer.className.replace(/\s*sided--no-fullscreen(\s*)/g, '$1');
             }
         }
     }
@@ -924,10 +904,10 @@ function toggleSideBySide(editor, onlyCleanup) {
 
     if (onlyCleanup) {
         // if not toggling, handle noFullscreen classes as needed
-        setupNoFullscreenClasses(sidePreviewActive);
+        setNoFullscreenClass(sidePreviewActive);
     } else if (sidePreviewActive) {
         // close side-by-side, and cleanup noFullscreen classes as needed
-        setupNoFullscreenClasses(false);
+        setNoFullscreenClass(false);
         preview.className = preview.className.replace(
             /\s*editor-preview-active-side\s*/g, ''
         );
@@ -941,7 +921,7 @@ function toggleSideBySide(editor, onlyCleanup) {
         setTimeout(function () {
             if (!cm.getOption('fullScreen')) {
                 if (editor.options.sideBySideFullscreen === false) {
-                    setupNoFullscreenClasses(true);
+                    setNoFullscreenClass(true);
                 } else {
                     toggleFullScreen(editor);
                 }
@@ -956,7 +936,7 @@ function toggleSideBySide(editor, onlyCleanup) {
 
     // Hide normal (full-pane) preview if active
     var previewNormal = wrapper.lastChild;
-    if (!dontToggle && /editor-preview-active/.test(previewNormal.className)) {
+    if (/editor-preview-active/.test(previewNormal.className)) {
         previewNormal.className = previewNormal.className.replace(
             /\s*editor-preview-active\s*/g, ''
         );


### PR DESCRIPTION
This is a fix for issues created by #286, as noted in #306.

The initial attempt to keep preview active when toggling full-screen, was to simply not call `toggleSideBySide()`, which unfortunately didn't account for "no-fullscreen" classes that are applied in the non-fullscreen side-by-side preview mode.

In this PR:
* move to applying`.sided--no-fullscreen` only to the parent element and using CSS inheritance
* on full-screen toggle, add/remove `.sided--no-fullscreen` as needed

For future refactoring, it would be cleaner to apply general status classes to the `.EasyMdeContainer`, such as `fullscreen sided` and have the sub-elements key off the parent class to avoid having to set classes on multiple elements.  This would allow all the `.EasyMdeContainer.sided--no-fullscreen ...` classes be replaced with `.EasyMdeContainer.sided:not(.fullscreen)`, with similar changes throughout the rest of the code (`.editor-toolbar.fullscreen` to `.EasyMdeContainer.fullscreen .editor-toolbar`, etc.).