### PR TITLE
Allow for specifying a custom spell-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **sanitizerFunction**: Custom function for sanitizing the HTML output of markdown renderer.
 - **shortcuts**: Keyboard shortcuts associated with this instance. Defaults to the [array of shortcuts](#keyboard-shortcuts).
 - **showIcons**: An array of icon names to show. Can be used to show specific icons hidden by default without completely customizing the toolbar.
-- **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.  Optionally pass a CodeMirrorSpellChecker compliant function.
+- **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.  Optionally pass a CodeMirrorSpellChecker-compliant function.
 - **inputStyle**: `textarea` or `contenteditable`. Defaults to `textarea` for desktop and `contenteditable` for mobile. `contenteditable` option is necessary to enable nativeSpellcheck.
 - **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`.
 - **sideBySideFullscreen**: If set to `false`, allows side-by-side editing without going into fullscreen. Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **sanitizerFunction**: Custom function for sanitizing the HTML output of markdown renderer.
 - **shortcuts**: Keyboard shortcuts associated with this instance. Defaults to the [array of shortcuts](#keyboard-shortcuts).
 - **showIcons**: An array of icon names to show. Can be used to show specific icons hidden by default without completely customizing the toolbar.
-- **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.
+- **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.  Optionally pass a CodeMirrorSpellChecker compliant function.
 - **inputStyle**: `textarea` or `contenteditable`. Defaults to `textarea` for desktop and `contenteditable` for mobile. `contenteditable` option is necessary to enable nativeSpellcheck.
 - **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`.
 - **sideBySideFullscreen**: If set to `false`, allows side-by-side editing without going into fullscreen. Defaults to `true`.

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2052,9 +2052,15 @@ EasyMDE.prototype.render = function (el) {
         backdrop.name = 'gfm';
         backdrop.gitHubSpice = false;
 
-        CodeMirrorSpellChecker({
-            codeMirrorInstance: CodeMirror,
-        });
+        if (typeof options.spellChecker === 'function') {
+            options.spellChecker({
+                codeMirrorInstance: CodeMirror,
+            });
+        } else {
+            CodeMirrorSpellChecker({
+                codeMirrorInstance: CodeMirror,
+            });
+        }
     }
 
     // eslint-disable-next-line no-unused-vars

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -165,6 +165,10 @@ declare namespace EasyMDE {
       combine?: boolean
     }
 
+    interface SpellCheckerOptions {
+        codeMirrorInstance: CodeMirror.Editor
+    }
+
     interface Options {
         autoDownloadFontAwesome?: boolean;
         autofocus?: boolean;
@@ -190,7 +194,7 @@ declare namespace EasyMDE {
         renderingConfig?: RenderingOptions;
         shortcuts?: Shortcuts;
         showIcons?: ReadonlyArray<ToolbarButton>;
-        spellChecker?: boolean;
+        spellChecker?: boolean | ((options: SpellCheckerOptions) => void);
         inputStyle?: 'textarea' | 'contenteditable';
         nativeSpellcheck?: boolean;
         sideBySideFullscreen?: boolean;


### PR DESCRIPTION
Allows passing a CodeMirrorSpellChecker function into EasyMDE for customized spell checking.   Most common use would likely be to pass in  edemaine/codemirror-spell-checker to avoid highlighting numbers, but this also opens the door for custom implementations and dictionaries.