### PR TITLE
fix: Formatting asterisks divided by space results in console error #337

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1200,7 +1200,7 @@ function _toggleLine(cm, name) {
     var _checkChar = function (name, char) {
         var map = {
             'quote': '>',
-            'unordered-list': '*',
+            'unordered-list': '\\*',
             'ordered-list': '\\d+.',
         };
         var rt = new RegExp(map[name]);


### PR DESCRIPTION
Fixes https://github.com/Ionaru/easy-markdown-editor/issues/337