### PR TITLE
Add the cleanup function to TypeScript definition

### DIFF
--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -233,6 +233,8 @@ declare class EasyMDE {
 
     codemirror: CodeMirror.Editor;
 
+    cleanup(): void;
+
     toTextArea(): void;
 
     isPreviewActive(): boolean;


### PR DESCRIPTION
# Why

I would like to use this function without having to hack the TypeScript definition.

# What 

Add the TypeScript definition for the `cleanup` function that was [previously introduced](https://github.com/Ionaru/easy-markdown-editor/pull/235)