### PR TITLE
Add support for RTL languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ easyMDE.value('New input for **EasyMDE**');
   - **underscoresBreakWords**: If set to `true`, let underscores be a delimiter for separating words. Defaults to `false`.
 - **overlayMode**: Pass a custom codemirror [overlay mode](https://codemirror.net/doc/manual.html#modeapi) to parse and style the Markdown during editing.
   - **mode**: A codemirror mode object.
-  - **combine**: If set to `false`, will *replace* CSS classes returned by the default Markdown mode. Otherwise the classes returned by the custom mode will be combined with the classes returned by the default mode. Defaults to `true`. 
+  - **combine**: If set to `false`, will *replace* CSS classes returned by the default Markdown mode. Otherwise the classes returned by the custom mode will be combined with the classes returned by the default mode. Defaults to `true`.
 - **placeholder**: If set, displays a custom placeholder message.
 - **previewClass**: A string or array of strings that will be applied to the preview screen when activated. Defaults to `"editor-preview"`.
 - **previewRender**: Custom function for parsing the plaintext Markdown and returning HTML. Used when user previews.
@@ -206,6 +206,7 @@ easyMDE.value('New input for **EasyMDE**');
 - **theme**: Override the theme. Defaults to `easymde`.
 - **toolbar**: If set to `false`, hide the toolbar. Defaults to the [array of icons](#toolbar-icons).
 - **toolbarTips**: If set to `false`, disable toolbar button tips. Defaults to `true`.
+- **direction**: `rtl` or `ltr`. Changes text direction to support right-to-left languages. Defaults to `ltr`.
 
 
 ### Options example

--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -2,6 +2,10 @@
     display: block;
 }
 
+.CodeMirror-rtl pre { 
+    direction: rtl; 
+}
+
 .EasyMDEContainer.sided--no-fullscreen {
     display: flex;
     flex-direction: row;

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1767,6 +1767,8 @@ function EasyMDE(options) {
     options.shortcuts = extend({}, shortcuts, options.shortcuts || {});
 
     options.maxHeight = options.maxHeight || undefined;
+    
+    options.direction = options.direction || 'ltr';
 
     if (typeof options.maxHeight !== 'undefined') {
         // Min and max height are equal if maxHeight is set
@@ -2080,6 +2082,7 @@ EasyMDE.prototype.render = function (el) {
         lineNumbers: (options.lineNumbers === true) ? true : false,
         autofocus: (options.autofocus === true) ? true : false,
         extraKeys: keyMaps,
+        direction: options.direction,
         lineWrapping: (options.lineWrapping === false) ? false : true,
         allowDropFileTypes: ['text/plain'],
         placeholder: options.placeholder || el.getAttribute('placeholder') || '',


### PR DESCRIPTION
Codemirror already supports RTL with the `direction` property. See [the official documentation](https://codemirror.net/doc/manual.html)

Adding a direction option to Easymde makes it RTL friendly while keeping the default LTR.