### PR TITLE
update easymde.css, fix issue #362

### DIFF
--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -361,7 +361,7 @@
 
 .easymde-dropdown:active .easymde-dropdown-content,
 .easymde-dropdown:focus .easymde-dropdown-content,
-.easymde-dropdown:focus-within .easymde-dropdown-content, {
+.easymde-dropdown:focus-within .easymde-dropdown-content {
     visibility: visible;
 }
 


### PR DESCRIPTION
Add :focus-within to solve easymde-dropdown-content exiting before execute actions on Chrome v95