### PR TITLE
Fix #381 Accurate line and column count in status bar

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2672,7 +2672,7 @@ EasyMDE.prototype.createStatusbar = function (status) {
                 };
                 onActivity = function (el) {
                     var pos = cm.getCursor();
-                    el.innerHTML = pos.line + ':' + pos.ch;
+                    el.innerHTML = pos.line + 1 + ':' + pos.ch;
                 };
             } else if (name === 'autosave') {
                 defaultValue = function (el) {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2672,7 +2672,9 @@ EasyMDE.prototype.createStatusbar = function (status) {
                 };
                 onActivity = function (el) {
                     var pos = cm.getCursor();
-                    el.innerHTML = pos.line + 1 + ':' + pos.ch;
+                    var posLine = pos.line + 1;
+                    var posColumn = pos.ch + 1;
+                    el.innerHTML = posLine + ':' + posColumn;
                 };
             } else if (name === 'autosave') {
                 defaultValue = function (el) {


### PR DESCRIPTION
Both line and column count in the status bar started at 0. In wordprocessors it's common to have them start at 1.
This fixes this issue.