### PR TITLE
Add CSS media query for dark mode

### DIFF
--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -380,3 +380,12 @@ span[data-img-src]::after {
     width: var(--width);
     background-repeat: no-repeat;
 }
+
+@media (prefers-color-scheme: dark) {
+    .editor-toolbar {
+        background: #333;
+    }
+    .editor-toolbar button {
+        color: #ddd;
+    }
+}


### PR DESCRIPTION
This adds a CSS media query for dark mode.
It makes the toolbar dark with bright icons.