### PR TITLE
Remove class name from buttons

### DIFF
--- a/cypress/integration/1-default-editor/preview.spec.js
+++ b/cypress/integration/1-default-editor/preview.spec.js
@@ -7,7 +7,7 @@ describe('Preview', () => {
 
     it('can show a preview of markdown text', () => {
         cy.get('.EasyMDEContainer').should('be.visible');
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('not.be.visible');
+        cy.get('.EasyMDEContainer .editor-preview').should('not.be.visible');
 
         // Enter markdown text.
         cy.get('.EasyMDEContainer .CodeMirror').type('# My Big Title');
@@ -25,7 +25,7 @@ describe('Preview', () => {
         cy.previewOn();
 
         // Check preview window for rendered markdown.
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<h1 id="my-big-title">My Big Title</h1>');
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p>This is some <strong>important</strong> text!</p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<h1 id="my-big-title">My Big Title</h1>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p>This is some <strong>important</strong> text!</p>');
     });
 });

--- a/cypress/integration/1-default-editor/preview.spec.js
+++ b/cypress/integration/1-default-editor/preview.spec.js
@@ -7,7 +7,7 @@ describe('Preview', () => {
 
     it('can show a preview of markdown text', () => {
         cy.get('.EasyMDEContainer').should('be.visible');
-        cy.get('.EasyMDEContainer .editor-preview').should('not.be.visible');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('not.be.visible');
 
         // Enter markdown text.
         cy.get('.EasyMDEContainer .CodeMirror').type('# My Big Title');
@@ -25,7 +25,7 @@ describe('Preview', () => {
         cy.previewOn();
 
         // Check preview window for rendered markdown.
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<h1 id="my-big-title">My Big Title</h1>');
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p>This is some <strong>important</strong> text!</p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<h1 id="my-big-title">My Big Title</h1>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p>This is some <strong>important</strong> text!</p>');
     });
 });

--- a/cypress/integration/2-url-prompt/url-prompt.spec.js
+++ b/cypress/integration/2-url-prompt/url-prompt.spec.js
@@ -23,7 +23,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             const stub = cy.stub($win, 'prompt');
-            cy.get('button.image').click().then(() => {
+            cy.get('button.mde-image').click().then(() => {
                 expect(stub).to.be.calledWith('URL of the image:', 'https://');
             });
         });
@@ -42,7 +42,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com" target="_blank">Link to a website!</a></p>');
     });
 
     it('can use the prompt multiple times', () => {
@@ -76,7 +76,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should(
+        cy.get('.EasyMDEContainer .mde-editor-preview').should(
             'contain.html',
             '<p><a href="https://example.com" target="_blank">Link to a website!</a><br><a href="https://example.eu" target="_blank">Link to a second website!</a></p>',
         );
@@ -95,7 +95,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=param&amp;moo=cow" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=param&amp;moo=cow" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with brackets in links', () => {
@@ -111,7 +111,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=%5B%5Dparam" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=%5B%5Dparam" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with parentheses in links', () => {
@@ -127,7 +127,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param)" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param)" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with parentheses in links (multiple)', () => {
@@ -143,7 +143,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param1,param2)&amp;more=(param3,param4)&amp;end=true" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param1,param2)&amp;more=(param3,param4)&amp;end=true" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with unbalanced parentheses in links (opening)', () => {
@@ -159,7 +159,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with unbalanced parentheses in links (closing)', () => {
@@ -175,7 +175,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=)param" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=)param" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with inequality symbols in links', () => {
@@ -191,7 +191,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=%3Cparam" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=%3Cparam" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with emoji in links', () => {
@@ -207,7 +207,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=%F0%9F%91%B7%E2%80%8D%E2%99%82%EF%B8%8F" target="_blank">Link to a 👌 website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=%F0%9F%91%B7%E2%80%8D%E2%99%82%EF%B8%8F" target="_blank">Link to a 👌 website!</a></p>');
     });
 
     it('must be able to deal with spaces in links', () => {
@@ -223,6 +223,6 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=very%20special%20param" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=very%20special%20param" target="_blank">Link to a website!</a></p>');
     });
 });

--- a/cypress/integration/2-url-prompt/url-prompt.spec.js
+++ b/cypress/integration/2-url-prompt/url-prompt.spec.js
@@ -11,7 +11,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             const stub = cy.stub($win, 'prompt');
-            cy.get('button.link').click().then(() => {
+            cy.get('button.mde-link').click().then(() => {
                 expect(stub).to.be.calledWith('URL for the link:', 'https://');
             });
         });
@@ -35,7 +35,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com)');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -52,7 +52,7 @@ describe('URL prompts', () => {
         cy.window().then(($win) => {
             const stub = cy.stub($win, 'prompt');
             stub.returns('https://example.com');
-            cy.get('button.link').click().then(() => {
+            cy.get('button.mde-link').click().then(() => {
                 expect(stub).to.be.calledWith('URL for the link:', 'https://');
                 stub.restore();
             });
@@ -63,7 +63,7 @@ describe('URL prompts', () => {
         cy.window().then(($win) => {
             const stub = cy.stub($win, 'prompt');
             stub.returns('https://example.eu');
-            cy.get('button.link').click().then(() => {
+            cy.get('button.mde-link').click().then(() => {
                 expect(stub).to.be.calledWith('URL for the link:', 'https://');
                 stub.restore();
             });
@@ -88,7 +88,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=param&moo=cow');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=param&moo=cow)');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -104,7 +104,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=[]param');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=%5B%5Dparam)');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -120,7 +120,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=(param)');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=\\(param\\))');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -136,7 +136,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=(param1,param2)&more=(param3,param4)&end=true');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=\\(param1,param2\\)&more=\\(param3,param4\\)&end=true)');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -152,7 +152,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=(param');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=\\(param)');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -168,7 +168,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=)param');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=\\)param)');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -184,7 +184,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=<param');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=%3Cparam');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');
@@ -200,7 +200,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=👷‍♂️');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=%F0%9F%91%B7%E2%80%8D%E2%99%82%EF%B8%8F');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a 👌 website!');
@@ -216,7 +216,7 @@ describe('URL prompts', () => {
 
         cy.window().then(($win) => {
             cy.stub($win, 'prompt').returns('https://example.com?some=very special param');
-            cy.get('button.link').click();
+            cy.get('button.mde-link').click();
         });
         cy.get('.EasyMDEContainer .CodeMirror').contains('[](https://example.com?some=very%20special%20param');
         cy.get('.EasyMDEContainer .CodeMirror').type('{home}{rightarrow}Link to a website!');

--- a/cypress/integration/2-url-prompt/url-prompt.spec.js
+++ b/cypress/integration/2-url-prompt/url-prompt.spec.js
@@ -42,7 +42,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com" target="_blank">Link to a website!</a></p>');
     });
 
     it('can use the prompt multiple times', () => {
@@ -76,7 +76,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should(
+        cy.get('.EasyMDEContainer .editor-preview').should(
             'contain.html',
             '<p><a href="https://example.com" target="_blank">Link to a website!</a><br><a href="https://example.eu" target="_blank">Link to a second website!</a></p>',
         );
@@ -95,7 +95,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=param&amp;moo=cow" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=param&amp;moo=cow" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with brackets in links', () => {
@@ -111,7 +111,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=%5B%5Dparam" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=%5B%5Dparam" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with parentheses in links', () => {
@@ -127,7 +127,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param)" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param)" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with parentheses in links (multiple)', () => {
@@ -143,7 +143,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param1,param2)&amp;more=(param3,param4)&amp;end=true" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param1,param2)&amp;more=(param3,param4)&amp;end=true" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with unbalanced parentheses in links (opening)', () => {
@@ -159,7 +159,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=(param" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with unbalanced parentheses in links (closing)', () => {
@@ -175,7 +175,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=)param" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=)param" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with inequality symbols in links', () => {
@@ -191,7 +191,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=%3Cparam" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=%3Cparam" target="_blank">Link to a website!</a></p>');
     });
 
     it('must be able to deal with emoji in links', () => {
@@ -207,7 +207,7 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=%F0%9F%91%B7%E2%80%8D%E2%99%82%EF%B8%8F" target="_blank">Link to a 👌 website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=%F0%9F%91%B7%E2%80%8D%E2%99%82%EF%B8%8F" target="_blank">Link to a 👌 website!</a></p>');
     });
 
     it('must be able to deal with spaces in links', () => {
@@ -223,6 +223,6 @@ describe('URL prompts', () => {
 
         cy.previewOn();
 
-        cy.get('.EasyMDEContainer .mde-editor-preview').should('contain.html', '<p><a href="https://example.com?some=very%20special%20param" target="_blank">Link to a website!</a></p>');
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p><a href="https://example.com?some=very%20special%20param" target="_blank">Link to a website!</a></p>');
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,16 +16,16 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('previewOn' , () => {
     cy.get('.EasyMDEContainer .editor-preview').should('not.be.visible');
-    cy.get('.EasyMDEContainer .editor-toolbar button.preview').should('not.have.class', 'active');
-    cy.get('.EasyMDEContainer .editor-toolbar button.preview').click();
-    cy.get('.EasyMDEContainer .editor-toolbar button.preview').should('have.class', 'active');
+    cy.get('.EasyMDEContainer .editor-toolbar button.mde-preview').should('not.have.class', 'active');
+    cy.get('.EasyMDEContainer .editor-toolbar button.mde-preview').click();
+    cy.get('.EasyMDEContainer .editor-toolbar button.mde-preview').should('have.class', 'active');
     cy.get('.EasyMDEContainer .editor-preview').should('be.visible');
 });
 
 Cypress.Commands.add('previewOff' , () => {
     cy.get('.EasyMDEContainer .editor-preview').should('be.visible');
-    cy.get('.EasyMDEContainer .editor-toolbar button.preview').should('have.class', 'active');
-    cy.get('.EasyMDEContainer .editor-toolbar button.preview').click();
-    cy.get('.EasyMDEContainer .editor-toolbar button.preview').should('not.have.class', 'active');
+    cy.get('.EasyMDEContainer .editor-toolbar button.mde-preview').should('have.class', 'active');
+    cy.get('.EasyMDEContainer .editor-toolbar button.mde-preview').click();
+    cy.get('.EasyMDEContainer .editor-toolbar button.mde-preview').should('not.have.class', 'active');
     cy.get('.EasyMDEContainer .editor-preview').should('not.be.visible');
 });

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -238,6 +238,7 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
         }
     }
 
+    el.className = 'mde-' + options.name;
     el.setAttribute('type', markup);
     enableTooltips = (enableTooltips == undefined) ? true : enableTooltips;
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -232,7 +232,6 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
         }
     }
 
-    el.className = options.name;
     el.setAttribute('type', markup);
     enableTooltips = (enableTooltips == undefined) ? true : enableTooltips;
 


### PR DESCRIPTION
The class names collide with built-in classes such as the "table" class in Bootstrap.
This results in the buttons inheriting the style from Bootstrap (or other frameworks) that define classes with those names.

https://getbootstrap.com/docs/5.2/content/tables/