### PR TITLE
Detached preview rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,11 @@ const editor = new EasyMDE({
             preview.innerHTML = customMarkdownParser(plainText);
         }, 250);
 
+        // If you return null, the innerHTML of the preview will not 
+        // be overwritten. Useful if you control the preview node's content via
+        // vdom diffing.
+        // return null;
+
         return "Loading...";
     },
     promptURLs: true,

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1124,7 +1124,11 @@ function togglePreview(editor) {
             toolbar_div.className += ' disabled-for-preview';
         }
     }
-    preview.innerHTML = editor.options.previewRender(editor.value(), preview);
+
+    var preview_result = editor.options.previewRender(editor.value(), preview);
+    if (preview_result !== null) {
+        preview.innerHTML = preview_result;
+    }
 
 }
 
@@ -2849,7 +2853,11 @@ EasyMDE.prototype.value = function (val) {
         if (this.isPreviewActive()) {
             var wrapper = cm.getWrapperElement();
             var preview = wrapper.lastChild;
-            preview.innerHTML = this.options.previewRender(val, preview);
+            var preview_result = this.options.previewRender(val, preview);
+            if (preview_result !== null) {
+                preview.innerHTML = preview_result;
+            }
+
         }
         return this;
     }

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -196,7 +196,7 @@ declare namespace EasyMDE {
         previewClass?: string | ReadonlyArray<string>;
         previewImagesInEditor?: boolean;
         imagesPreviewHandler?: (src: string) => string,
-        previewRender?: (markdownPlaintext: string, previewElement: HTMLElement) => string;
+        previewRender?: (markdownPlaintext: string, previewElement: HTMLElement) => string | null;
         promptURLs?: boolean;
         renderingConfig?: RenderingOptions;
         shortcuts?: Shortcuts;


### PR DESCRIPTION
This is a very simple PR to allow more flexibility when rendering the preview. At the moment the `innerHTML` of the preview node will be overwritten with the result from `previewRender` with every showing of the preview. If you want to control this node via external means, for example with vdom diffing frameworks like Mithril.js or React, this gets in your way. With this change, the `innerHtml` of the preview node will only be overwritten if the result of `previewRender` is not null. I updated the type definitions and documentation accordingly.