### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ const easyMDE = new EasyMDE({
             className: "fa fa-bold",
             title: "Bold",
         },
-        "italics", // shortcut to pre-made button
+        "italic", // shortcut to pre-made button
         {
             name: "custom",
             action: (editor) => {


### PR DESCRIPTION
This is meant to be "italic" not "italics" which will render an empty icon here. The docs specify this as well and I tested locally while working through implementing this on a project.