### PR TITLE
Add missed "upload-image" icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ ordered-list | toggleOrderedList | Numbered List<br>fa fa-list-ol
 clean-block | cleanBlock | Clean block<br>fa fa-eraser
 link | drawLink | Create Link<br>fa fa-link
 image | drawImage | Insert Image<br>fa fa-picture-o
+upload-image | drawUploadedImage | Raise browse-file window<br>fa fa-image
 table | drawTable | Insert Table<br>fa fa-table
 horizontal-rule | drawHorizontalRule | Insert Horizontal Line<br>fa fa-minus
 preview | togglePreview | Toggle Preview<br>fa fa-eye no-disable


### PR DESCRIPTION
Once I set `uploadImage: true`, the browse-file window didn't raise, which confused me for a long time.
After I check the source code, I found there are two button for image.
- `image`
- `upload-image`

The default one is `image`.
I thinks `upload-image` should be written in doc, cause not everyone likes to check source code.

By the way, I think the examples you provided are not adequate, especially for those custom functions like `imageUploadFunction`. You should write some simple examples for them, not just provide a big project to let others understand.
``` js
imageUploadFunction: (file, onSuccess, onError) => {
                let form = new FormData
                form.append('file', file)
                axios({
                    method: 'post',
                    url: '/admin/upload',
                    data: form,
                }).then((res)=>{
                    if(res.data.success){
                        onSuccess(res.data.url)
                    }
                    else{
                        onError(res.data.error)
                    }
                })
            },
```
This is my example.
To figure it out, I searched issues, and found #376 which mentioned a [project](https://github.com/erossini/BlazorMarkdownEditor), and searched a lot to understand it.

But no one need to understand big project. A simple example is concise and easy to understand.
Maybe I'm a noob. But there are a lot of noobs.

But still, thanks for your project. I really enjoy it in my blog.