### PR TITLE
Expose CodeMirror as static property

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2877,6 +2877,12 @@ EasyMDE.prototype.value = function (val) {
 
 
 /**
+ * Expose CodeMirror as static property.
+ */
+EasyMDE.CodeMirror = CodeMirror;
+
+
+/**
  * Bind static methods for exports.
  */
 EasyMDE.toggleBold = toggleBold;


### PR DESCRIPTION
As requested in https://github.com/Ionaru/easy-markdown-editor/issues/495#issuecomment-1232130092 :)

> Unfortunately the CodeMirror object from EasyMDE is not available at that moment, although exposing it on the EasyMDE object should not be difficult (EasyMDE.CodeMirror = CodeMirror; in easymde.js, PR anyone? 😉).