### PR TITLE
Expose the `"upload-image"` variant for `ToolbarButton`

### DIFF
--- a/types/easymde-test.ts
+++ b/types/easymde-test.ts
@@ -209,6 +209,7 @@ new EasyMDE({
         'unordered-list',
         'ordered-list',
         'table',
+        'upload-image',
         '|',
         'link',
     ],

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -35,6 +35,7 @@ type ToolbarButton =
     | 'ordered-list'
     | 'link'
     | 'image'
+    | 'upload-image'
     | 'strikethrough'
     | 'code'
     | 'table'


### PR DESCRIPTION
This PR allows using the `"upload-image"` value for the `ToolbarButton` type.