### PR TITLE
Expose the `options` field type

### DIFF
--- a/types/easymde-test.ts
+++ b/types/easymde-test.ts
@@ -34,6 +34,30 @@ EasyMDE.toggleItalic = (editor: EasyMDE) => {
     console.log('SomeButtonOverride');
 };
 
+console.log(editor.options.blockStyles.bold);
+console.log(editor.options.insertTexts.horizontalRule[0]);
+console.log(editor.options.minHeight);
+console.log(editor.options.parsingConfig.allowAtxHeaderWithoutSpace);
+console.log(editor.options.previewClass);
+console.log(editor.options.previewRender('Hello', document.body));
+console.log(editor.options.shortcuts.cleanBlock);
+console.log(editor.options.status);
+console.log(editor.options.toolbar);
+
+console.log(editor.options.uploadImage);
+console.log(editor.options.imageMaxSize);
+console.log(editor.options.imageAccept);
+console.log(editor.options.imagePathAbsolute);
+console.log(editor.options.imageCSRFName);
+console.log(editor.options.imageCSRFHeader);
+console.log(editor.options.imageTexts.sbInit);
+console.log(editor.options.errorMessages.fileTooLarge);
+console.log(editor.options.errorCallback('Something went oops!'));
+
+console.log(editor.options.promptTexts.image);
+
+console.log(editor.options.direction);
+
 const editor2 = new EasyMDE({
     autoDownloadFontAwesome: undefined,
     previewClass: ['my-custom-class', 'some-other-class'],

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -53,6 +53,32 @@ type ToolbarButton =
     | 'fullscreen'
     | 'guide';
 
+interface InstanceOptions extends EasyMDE {
+    blockStyles: EasyMDE.BlockStyleOptions;
+    insertTexts: EasyMDE.InsertTextOptions;
+    minHeight: string;
+    parsingConfig: EasyMDE.ParsingOptions;
+    previewClass: string | ReadonlyArray<string>;
+    previewRender: (markdownPlaintext: string, previewElement: HTMLElement) => string | null;
+    shortcuts: EasyMDE.Shortcuts;
+    status: boolean | ReadonlyArray<string | EasyMDE.StatusBarItem>;
+    toolbar: boolean | ReadonlyArray<'|' | ToolbarButton | EasyMDE.ToolbarIcon | EasyMDE.ToolbarDropdownIcon>;
+
+    uploadImage: boolean;
+    imageMaxSize: number;
+    imageAccept: string;
+    imagePathAbsolute: boolean;
+    imageCSRFName: string;
+    imageCSRFHeader: boolean;
+    imageTexts: EasyMDE.ImageTextsOptions;
+    errorMessages: EasyMDE.ImageErrorTextsOptions;
+    errorCallback: (errorMessage: string) => void;
+
+    promptTexts: EasyMDE.PromptTexts;
+
+    direction: 'ltr' | 'rtl';
+}
+
 declare namespace EasyMDE {
 
     interface TimeFormatOptions {
@@ -245,67 +271,7 @@ declare class EasyMDE {
     value(val: string): void;
 
     codemirror: CodeMirror.Editor;
-    options: {
-        autoDownloadFontAwesome?: boolean;
-        autofocus?: boolean;
-        autosave?: EasyMDE.AutoSaveOptions;
-        autoRefresh?: boolean | { delay: number; };
-        blockStyles?: EasyMDE.BlockStyleOptions;
-        element?: HTMLElement;
-        forceSync?: boolean;
-        hideIcons?: ReadonlyArray<ToolbarButton>;
-        indentWithTabs?: boolean;
-        initialValue?: string;
-        insertTexts?: EasyMDE.InsertTextOptions;
-        lineNumbers?: boolean;
-        lineWrapping?: boolean;
-        minHeight?: string;
-        maxHeight?: string;
-        parsingConfig?: EasyMDE.ParsingOptions;
-        placeholder?: string;
-        previewClass?: string | ReadonlyArray<string>;
-        previewImagesInEditor?: boolean;
-        imagesPreviewHandler?: (src: string) => string,
-        previewRender?: (markdownPlaintext: string, previewElement: HTMLElement) => string | null;
-        promptURLs?: boolean;
-        renderingConfig?: EasyMDE.RenderingOptions;
-        shortcuts?: EasyMDE.Shortcuts;
-        showIcons?: ReadonlyArray<ToolbarButton>;
-        spellChecker?: boolean | ((options: EasyMDE.SpellCheckerOptions) => void);
-        inputStyle?: 'textarea' | 'contenteditable';
-        nativeSpellcheck?: boolean;
-        sideBySideFullscreen?: boolean;
-        status?: boolean | ReadonlyArray<string | EasyMDE.StatusBarItem>;
-        styleSelectedText?: boolean;
-        tabSize?: number;
-        toolbar?: boolean | ReadonlyArray<'|' | ToolbarButton | EasyMDE.ToolbarIcon | EasyMDE.ToolbarDropdownIcon>;
-        toolbarTips?: boolean;
-        toolbarButtonClassPrefix?: string;
-        onToggleFullScreen?: (goingIntoFullScreen: boolean) => void;
-        theme?: string;
-        scrollbarStyle?: string;
-        unorderedListStyle?: '*' | '-' | '+';
-
-        uploadImage?: boolean;
-        imageMaxSize?: number;
-        imageAccept?: string;
-        imageUploadFunction?: (file: File, onSuccess: (url: string) => void, onError: (error: string) => void) => void;
-        imageUploadEndpoint?: string;
-        imagePathAbsolute?: boolean;
-        imageCSRFToken?: string;
-        imageCSRFName?: string;
-        imageCSRFHeader?: boolean;
-        imageTexts?: EasyMDE.ImageTextsOptions;
-        errorMessages?: EasyMDE.ImageErrorTextsOptions;
-        errorCallback?: (errorMessage: string) => void;
-
-        promptTexts?: EasyMDE.PromptTexts;
-        syncSideBySidePreviewScroll?: boolean;
-
-        overlayMode?: EasyMDE.OverlayModeOptions;
-
-        direction?: 'ltr' | 'rtl';
-    }
+    options: InstanceOptions;
 
     cleanup(): void;
 

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -54,13 +54,13 @@ type ToolbarButton =
     | 'guide';
 
 interface InstanceOptions extends EasyMDE {
-    blockStyles: EasyMDE.BlockStyleOptions;
-    insertTexts: EasyMDE.InsertTextOptions;
+    blockStyles: Required<EasyMDE.BlockStyleOptions>;
+    insertTexts: Required<EasyMDE.InsertTextOptions>;
     minHeight: string;
     parsingConfig: EasyMDE.ParsingOptions;
     previewClass: string | ReadonlyArray<string>;
     previewRender: (markdownPlaintext: string, previewElement: HTMLElement) => string | null;
-    shortcuts: EasyMDE.Shortcuts;
+    shortcuts: Required<EasyMDE.Shortcuts>;
     status: boolean | ReadonlyArray<string | EasyMDE.StatusBarItem>;
     toolbar: boolean | ReadonlyArray<'|' | ToolbarButton | EasyMDE.ToolbarIcon | EasyMDE.ToolbarDropdownIcon>;
 
@@ -70,11 +70,11 @@ interface InstanceOptions extends EasyMDE {
     imagePathAbsolute: boolean;
     imageCSRFName: string;
     imageCSRFHeader: boolean;
-    imageTexts: EasyMDE.ImageTextsOptions;
-    errorMessages: EasyMDE.ImageErrorTextsOptions;
+    imageTexts: Required<EasyMDE.ImageTextsOptions>;
+    errorMessages: Required<EasyMDE.ImageErrorTextsOptions>;
     errorCallback: (errorMessage: string) => void;
 
-    promptTexts: EasyMDE.PromptTexts;
+    promptTexts: Required<EasyMDE.PromptTexts>;
 
     direction: 'ltr' | 'rtl';
 }

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -71,7 +71,9 @@ interface InstanceOptions extends SetRequired<EasyMDE.Options, 'minHeight' |
     'direction'> {
     blockStyles: Required<EasyMDE.BlockStyleOptions>;
     insertTexts: Required<EasyMDE.InsertTextOptions>;
-    shortcuts: Required<EasyMDE.Shortcuts>;
+    shortcuts: {
+        [P in keyof EasyMDE.Shortcuts]-?: NonNullable<EasyMDE.Shortcuts[P]>;
+    };
 
     imageTexts: Required<EasyMDE.ImageTextsOptions>;
     errorMessages: Required<EasyMDE.ImageErrorTextsOptions>;

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -27,6 +27,8 @@ interface ArrayOneOrMore<T> extends Array<T> {
     0: T;
 }
 
+type SetRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
 type ToolbarButton =
     'bold'
     | 'italic'
@@ -53,30 +55,28 @@ type ToolbarButton =
     | 'fullscreen'
     | 'guide';
 
-interface InstanceOptions extends EasyMDE {
+interface InstanceOptions extends SetRequired<EasyMDE.Options, 'minHeight' |
+    'parsingConfig' |
+    'previewClass' |
+    'previewRender' |
+    'status' |
+    'toolbar' |
+    'uploadImage' |
+    'imageMaxSize' |
+    'imageAccept' |
+    'imagePathAbsolute' |
+    'imageCSRFName' |
+    'imageCSRFHeader' |
+    'errorCallback' |
+    'direction'> {
     blockStyles: Required<EasyMDE.BlockStyleOptions>;
     insertTexts: Required<EasyMDE.InsertTextOptions>;
-    minHeight: string;
-    parsingConfig: EasyMDE.ParsingOptions;
-    previewClass: string | ReadonlyArray<string>;
-    previewRender: (markdownPlaintext: string, previewElement: HTMLElement) => string | null;
     shortcuts: Required<EasyMDE.Shortcuts>;
-    status: boolean | ReadonlyArray<string | EasyMDE.StatusBarItem>;
-    toolbar: boolean | ReadonlyArray<'|' | ToolbarButton | EasyMDE.ToolbarIcon | EasyMDE.ToolbarDropdownIcon>;
 
-    uploadImage: boolean;
-    imageMaxSize: number;
-    imageAccept: string;
-    imagePathAbsolute: boolean;
-    imageCSRFName: string;
-    imageCSRFHeader: boolean;
     imageTexts: Required<EasyMDE.ImageTextsOptions>;
     errorMessages: Required<EasyMDE.ImageErrorTextsOptions>;
-    errorCallback: (errorMessage: string) => void;
 
     promptTexts: Required<EasyMDE.PromptTexts>;
-
-    direction: 'ltr' | 'rtl';
 }
 
 declare namespace EasyMDE {

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -245,6 +245,67 @@ declare class EasyMDE {
     value(val: string): void;
 
     codemirror: CodeMirror.Editor;
+    options: {
+        autoDownloadFontAwesome?: boolean;
+        autofocus?: boolean;
+        autosave?: EasyMDE.AutoSaveOptions;
+        autoRefresh?: boolean | { delay: number; };
+        blockStyles?: EasyMDE.BlockStyleOptions;
+        element?: HTMLElement;
+        forceSync?: boolean;
+        hideIcons?: ReadonlyArray<ToolbarButton>;
+        indentWithTabs?: boolean;
+        initialValue?: string;
+        insertTexts?: EasyMDE.InsertTextOptions;
+        lineNumbers?: boolean;
+        lineWrapping?: boolean;
+        minHeight?: string;
+        maxHeight?: string;
+        parsingConfig?: EasyMDE.ParsingOptions;
+        placeholder?: string;
+        previewClass?: string | ReadonlyArray<string>;
+        previewImagesInEditor?: boolean;
+        imagesPreviewHandler?: (src: string) => string,
+        previewRender?: (markdownPlaintext: string, previewElement: HTMLElement) => string | null;
+        promptURLs?: boolean;
+        renderingConfig?: EasyMDE.RenderingOptions;
+        shortcuts?: EasyMDE.Shortcuts;
+        showIcons?: ReadonlyArray<ToolbarButton>;
+        spellChecker?: boolean | ((options: EasyMDE.SpellCheckerOptions) => void);
+        inputStyle?: 'textarea' | 'contenteditable';
+        nativeSpellcheck?: boolean;
+        sideBySideFullscreen?: boolean;
+        status?: boolean | ReadonlyArray<string | EasyMDE.StatusBarItem>;
+        styleSelectedText?: boolean;
+        tabSize?: number;
+        toolbar?: boolean | ReadonlyArray<'|' | ToolbarButton | EasyMDE.ToolbarIcon | EasyMDE.ToolbarDropdownIcon>;
+        toolbarTips?: boolean;
+        toolbarButtonClassPrefix?: string;
+        onToggleFullScreen?: (goingIntoFullScreen: boolean) => void;
+        theme?: string;
+        scrollbarStyle?: string;
+        unorderedListStyle?: '*' | '-' | '+';
+
+        uploadImage?: boolean;
+        imageMaxSize?: number;
+        imageAccept?: string;
+        imageUploadFunction?: (file: File, onSuccess: (url: string) => void, onError: (error: string) => void) => void;
+        imageUploadEndpoint?: string;
+        imagePathAbsolute?: boolean;
+        imageCSRFToken?: string;
+        imageCSRFName?: string;
+        imageCSRFHeader?: boolean;
+        imageTexts?: EasyMDE.ImageTextsOptions;
+        errorMessages?: EasyMDE.ImageErrorTextsOptions;
+        errorCallback?: (errorMessage: string) => void;
+
+        promptTexts?: EasyMDE.PromptTexts;
+        syncSideBySidePreviewScroll?: boolean;
+
+        overlayMode?: EasyMDE.OverlayModeOptions;
+
+        direction?: 'ltr' | 'rtl';
+    }
 
     cleanup(): void;
 


### PR DESCRIPTION
This PR exposes the `EasyMDE.prototype.options` field and marks the guaranteed fields as non-nullable.