### PR TITLE
Fix `ToolbarIcon` type.

### DIFF
--- a/types/easymde-test.ts
+++ b/types/easymde-test.ts
@@ -82,6 +82,7 @@ const editor2 = new EasyMDE({
                     name: 'link',
                     action: 'https://github.com/Ionaru/easy-markdown-editor',
                     className: 'fa fab fa-github',
+                    text: 'A Custom Link',
                     title: 'A Custom Link',
                     noDisable: true,
                     noMobile: true,

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -144,6 +144,7 @@ declare namespace EasyMDE {
         name: string;
         action: string | ((editor: EasyMDE) => void);
         className: string;
+        text?: string;
         title: string;
         noDisable?: boolean;
         noMobile?: boolean;


### PR DESCRIPTION
Hello, my name is nonz250.

I feel like `ToolbarIcon` is missing `text`.

Maybe it has something to do with this pull request.

https://github.com/Ionaru/easy-markdown-editor/pull/461

by deepl.