### PR TITLE
Fixed the toggling behaviour in toggleLinks.

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1275,7 +1275,7 @@ function _toggleLink(editor, type, startEnd, url) {
     var end = text.slice(startPoint.ch);
 
     if (type == 'link') {
-        start = start.replace(/(.*)[^!]\[/, '$1');
+        start = start.replace(/(.*[^!]*)\[/, '$1');
     } else if (type == 'image') {
         start = start.replace(/(.*)!\[$/, '$1');
     }


### PR DESCRIPTION
This pull request fixes a small issue in the `toggleLinks` method.

Suppose I have selected the text `uri` and then press `Cmd+K` to create a link. Then the text `[uri](https://)` will be generated. If I press `Cmd+K` again, it currently reverts the text back to `[uri` instead of `uri`. 

I have made a small correction to the regular expression in the `toggleLinks` method to fix this problem.