### PR TITLE
Add method to allow the adding of custom bindings

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2875,6 +2875,9 @@ EasyMDE.prototype.value = function (val) {
     }
 };
 
+EasyMDE.prototype.addBinding = function(name, method) {
+    bindings[name] = method;
+};
 
 /**
  * Bind static methods for exports.


### PR DESCRIPTION
I wanted to add a new keyboard shortcut but was unable to. This is because the list of bindings was set and no way to update it. This change adds a method that allows the user to add new bindings so you can have custom keyboard shortcuts