### PR TITLE
Allow setting a custom `name` for the upload-image input

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1870,6 +1870,7 @@ function EasyMDE(options) {
     options.imagePathAbsolute = options.imagePathAbsolute || false;
     options.imageCSRFName = options.imageCSRFName || 'csrfmiddlewaretoken';
     options.imageCSRFHeader = options.imageCSRFHeader || false;
+    options.imageInputName = options.imageInputName || 'image';
 
 
     // Change unique_id to uniqueId for backwards compatibility
@@ -2689,7 +2690,7 @@ EasyMDE.prototype.createToolbar = function (items) {
                 imageInput.className = 'imageInput';
                 imageInput.type = 'file';
                 imageInput.multiple = true;
-                imageInput.name = 'image';
+                imageInput.name = self.options.imageInputName;
                 imageInput.accept = self.options.imageAccept;
                 imageInput.style.display = 'none';
                 imageInput.style.opacity = 0;

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -227,6 +227,7 @@ declare namespace EasyMDE {
         imageCSRFName?: string;
         imageCSRFHeader?: boolean;
         imageTexts?: ImageTextsOptions;
+        imageInputName?: string
         errorMessages?: ImageErrorTextsOptions;
         errorCallback?: (errorMessage: string) => void;
 


### PR DESCRIPTION
Fix for https://github.com/Ionaru/easy-markdown-editor/issues/571.

By setting imageInputName you can customize the name of the input used by EasyMDE to upload images. By default it is set to 'image' as it was before.

```js
new EasyMDE({element: document.getElementById('my-textarea'), imageInputName: "easyMDEImage", toolbar: ['upload-image']})
```

```html
<input class="imageInput" type="file" multiple="" name="easyMDEImage" accept="image/png, image/jpeg, image/gif, image/avif" style="display: none; opacity: 0;">
```
