### PR TITLE
fix: the wrong text is inserted after uploading an image

### DIFF
--- a/cypress/e2e/4-image-upload/index.html
+++ b/cypress/e2e/4-image-upload/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Default</title>
+    <link rel="stylesheet" href="../../../dist/easymde.min.css">
+    <script src="../../../dist/easymde.min.js"></script>
+</head>
+
+<body>
+    <textarea id="textarea"></textarea>
+    <script>
+        const easyMDE = new EasyMDE({
+            uploadImage: true,
+            showIcons: ["upload-image"],
+            imageUploadFunction: (file, onSuccess) => {
+                onSuccess('https://test.com/test.jpg')
+            }
+        });
+    </script>
+</body>
+
+</html>

--- a/cypress/e2e/4-image-upload/upload.cy.js
+++ b/cypress/e2e/4-image-upload/upload.cy.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+describe('Upload', () => {
+    beforeEach(() => {
+        cy.visit(__dirname + '/index.html');
+    });
+
+    it('upload an image should insert a mock image url', () => {
+        cy.get('.EasyMDEContainer button.upload-image').click();
+        cy.get('.EasyMDEContainer input[type=file]').selectFile({
+            contents: Cypress.Buffer.from('', 'utf-8'),
+            fileName: 'test.jpg',
+            mimeType: 'image/jpeg'
+        }, {
+            action: 'drag-drop',
+            force: true
+        });
+        cy.get('.EasyMDEContainer .CodeMirror').contains('![test.jpg](https://test.com/test.jpg)');
+    });
+});

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -878,18 +878,10 @@ function afterImageUploaded(editor, url) {
     var cm = editor.codemirror;
     var stat = getState(cm);
     var options = editor.options;
+    // TODO: Get the image name from the original file name
     var imageName = url.substr(url.lastIndexOf('/') + 1);
-    var ext = imageName.substring(imageName.lastIndexOf('.') + 1).replace(/\?.*$/, '').toLowerCase();
-
-    // Check if media is an image
-    if (['png', 'jpg', 'jpeg', 'gif', 'svg', 'apng', 'avif', 'webp'].includes(ext)) {
-        _replaceSelection(cm, stat.image, options.insertTexts.uploadedImage, url);
-    } else {
-        var text_link = options.insertTexts.link;
-        text_link[0] = '[' + imageName;
-        _replaceSelection(cm, stat.link, text_link, url);
-    }
-
+    var text_link = [`${options.insertTexts.image[0]}${imageName}`, options.insertTexts.image[1]];
+    _replaceSelection(cm, stat.image, text_link, url);
     // show uploaded image filename for 1000ms
     editor.updateStatusBar('upload-image', editor.options.imageTexts.sbOnUploaded.replace('#image_name#', imageName));
     setTimeout(function () {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #334, #574.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The original code inserted a link text after uploading the image. This pull request will correct it and ensure that the image name is respected when the file extension is included, particularly for known image extensions.
