### PR TITLE
Fix relative image url fetched from stylesheet domain

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2233,8 +2233,9 @@ EasyMDE.prototype.render = function (el) {
 
 
     function assignImageBlockAttributes(parentEl, img) {
-        parentEl.setAttribute('data-img-src', img.url);
-        parentEl.setAttribute('style', '--bg-image:url(' + img.url + ');--width:' + img.naturalWidth + 'px;--height:' + calcHeight(img.naturalWidth, img.naturalHeight));
+        var url = (new URL(img.url, document.baseURI)).href;
+        parentEl.setAttribute('data-img-src', url);
+        parentEl.setAttribute('style', '--bg-image:url(' + url + ');--width:' + img.naturalWidth + 'px;--height:' + calcHeight(img.naturalWidth, img.naturalHeight));
         _vm.codemirror.setSize();
     }
 


### PR DESCRIPTION
Partial URLs are interpreted relative to the source of the style sheet, not relative to the document
https://www.w3.org/TR/CSS1/

---

Before the patch, if the stylesheet is hosted on a remote host, the background images are retrieved from the stylesheet domain. For instance, on the following example, /img/1.jpg is fetched from https://cnd.jsdelivr.net/

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css" />
  </head>
  <body>
    <textarea id="my-text-area">
![](/img/1.jpg)
    </textarea>
[...]
  </body>
</html>
```

