### PR TITLE
Avoid processing many times the same image

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2267,6 +2267,7 @@ EasyMDE.prototype.render = function (el) {
                     }
 
                     if (!window.EMDEimagesCache[keySrc]) {
+                        window.EMDEimagesCache[keySrc] = {};
                         var img = document.createElement('img');
                         img.onload = function () {
                             window.EMDEimagesCache[keySrc] = {


### PR DESCRIPTION
Cache img key during processing to avoid having to process it thousands of times

Fix #579 