### PR TITLE
Selective heading levels

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,11 +13,7 @@
 <body>
     <textarea></textarea>
     <script>
-        const easyMDE = new EasyMDE({
-            parsingConfig: {
-                headingLevels: [ 5, 2, 3, 5 ]
-            }
-        });
+        const easyMDE = new EasyMDE();
     </script>
 </body>
 

--- a/example/index.html
+++ b/example/index.html
@@ -15,7 +15,7 @@
     <script>
         const easyMDE = new EasyMDE({
             parsingConfig: {
-                headingLevels: [ 5, 2, 3, 4, 5 ]
+                headingLevels: [ 5, 2, 3, 5 ]
             }
         });
     </script>

--- a/example/index.html
+++ b/example/index.html
@@ -13,7 +13,11 @@
 <body>
     <textarea></textarea>
     <script>
-        const easyMDE = new EasyMDE();
+        const easyMDE = new EasyMDE({
+            parsingConfig: {
+                headingLevels: [ 5, 2, 3, 4, 5 ]
+            }
+        });
     </script>
 </body>
 

--- a/example/index_parsingConfig_headingLevels.html
+++ b/example/index_parsingConfig_headingLevels.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Example / Preview / parsingConfig / headingLevels</title>
+    <link rel="stylesheet" href="../dist/easymde.min.css">
+    <script src="../dist/easymde.min.js"></script>
+</head>
+
+<body>
+    <textarea>## Lorem Ipsum
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. **Aliquam odio enim**, porta in odio eu, posuere blandit ipsum. Donec non eleifend nulla. Nullam mattis viverra tortor in rutrum. Phasellus non auctor dolor, laoreet aliquam purus. Pellentesque eget tempus sem, et tempus neque. *Etiam fringilla id odio nec feugiat*.
+Quisque vitae orci eget quam auctor bibendum. Donec dapibus libero non tortor condimentum, **sed lobortis quam tempor**. Morbi purus nisi, maximus ac libero sed, sollicitudin dictum mi. Ut nibh quam, efficitur vel vulputate quis, efficitur nec dui. Ut ut ultricies eros. Pellentesque et nisl at augue ullamcorper tempor. Cras quam risus, commodo a interdum in, vestibulum a ligula. Vestibulum et aliquam nulla.
+### Dolor Sit Amet</textarea>
+    <script>
+        const easyMDE = new EasyMDE({
+            parsingConfig: {
+                headingLevels: [ 5, 2, 3, 5 ]
+            }
+        });
+    </script>
+</body>
+
+</html>

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2461,7 +2461,7 @@ EasyMDE.prototype.render = function (el) {
                     // Be gentle and set back the cursor at the appropriate position
                     cm.doc.setCursor({
                         line: obj.to.line,
-                        ch: (delChar === 1 ? obj.to.ch : obj.to.ch - 8) - myLevels.diff,
+                        ch: obj.text[0].length + 1,
                     });
                     return true;
                 }
@@ -2544,6 +2544,7 @@ EasyMDE.prototype.render = function (el) {
                         });
                         if (/#/.test(startText)) {
                             oldText = startText + obj.text[r];
+                            oldText = oldText.replace(/#\s+#/, '##');
                             newText = headingCheckRow(oldText, cm);
                             if (oldText !== newText) { // A modification has been made
                                 obj.text[r] = newText.substring(obj.from.ch);
@@ -2560,6 +2561,7 @@ EasyMDE.prototype.render = function (el) {
                         });
                         if (/#/.test(endText)) {
                             oldText = obj.text[r] + endText;
+                            oldText = oldText.replace(/#\s+#/, '##');
                             newText = headingCheckRow(oldText, cm);
                             if (oldText !== newText) { // A modification has been made
                                 obj.text[r] = newText.replace(endText, '');
@@ -2594,6 +2596,7 @@ EasyMDE.prototype.render = function (el) {
                     ch: obj.to.ch + 8,
                 });
                 oldText = startText + endText;
+                oldText = oldText.replace(/#\s+#/, '##');
                 if (/#/.test(oldText)) {
                     newText = headingCheckRow(oldText, cm);
                     if (oldText !== newText) { // A modification has been made

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2461,7 +2461,7 @@ EasyMDE.prototype.render = function (el) {
                     // Be gentle and set back the cursor at the appropriate position
                     cm.doc.setCursor({
                         line: obj.to.line,
-                        ch: obj.text[0].length + 1,
+                        ch: obj.text[0].length ? obj.text[0].length + 1 : 0,
                     });
                     return true;
                 }

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1124,7 +1124,7 @@ function _toggleHeading(cm, direction, size) {
 
     var startPoint = cm.getCursor('start');
     var endPoint = cm.getCursor('end');
-    var sharpLevels = cm.options.backdrop.headingLevels || [],
+    var sharpLevels = cm.options.backdrop ? (cm.options.backdrop.headingLevels || []) : (cm.mode ? (cm.mode.headingLevels || []) : []),
         minLevel = sharpLevels.length ? sharpLevels[0] : 1,
         maxLevel = sharpLevels.length ? sharpLevels[sharpLevels.length-1] : 6;
     if (size && sharpLevels.length && sharpLevels.indexOf(size) === -1) {
@@ -2318,7 +2318,7 @@ EasyMDE.prototype.render = function (el) {
                 line: obj.to.line,
                 ch: obj.to.ch,
             });
-            var myLevels = headingNeedUpdate(currHeading, cm.options.backdrop.headingLevels);
+            var myLevels = headingNeedUpdate(currHeading, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.mode.headingLevels);
             if (!myLevels || !myLevels.from || !myLevels.to) {
                 return false;
             }
@@ -2380,7 +2380,7 @@ EasyMDE.prototype.render = function (el) {
                     } else {
                         myText = myText.replace(/#/, '##'); // Increment one sharp sign
                     }
-                    myLevels = headingNeedUpdate(myText, cm.options.backdrop.headingLevels);
+                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.mode.headingLevels);
                     if (!myLevels) {
                         return false;
                     }
@@ -2439,7 +2439,7 @@ EasyMDE.prototype.render = function (el) {
                             ch: obj.to.ch + 8,
                         };
                     }
-                    myLevels = headingNeedUpdate(myText, cm.options.backdrop.headingLevels, searchDir);
+                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.mode.headingLevels, searchDir);
                     if (!myLevels || !myLevels.diff) {
                         return false;
                     }
@@ -2472,7 +2472,7 @@ EasyMDE.prototype.render = function (el) {
                 return row;
             }
             row = row.replace(/^(\s*)#/, '#');
-            var myLevels = headingNeedUpdate(row, cm.options.backdrop.headingLevels);
+            var myLevels = headingNeedUpdate(row, cm.mode.headingLevels || cm.options.backdrop.headingLevels);
             if (!myLevels || !myLevels.from || !myLevels.to) {
                 return row;
             } else if (myLevels.from < myLevels.to) {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1124,6 +1124,13 @@ function _toggleHeading(cm, direction, size) {
 
     var startPoint = cm.getCursor('start');
     var endPoint = cm.getCursor('end');
+    var sharpLevels = cm.options.backdrop.headingLevels || [],
+        minLevel = sharpLevels.length ? sharpLevels[0] : 1,
+        maxLevel = sharpLevels.length ? sharpLevels[sharpLevels.length-1] : 6;
+    if (size && sharpLevels.length && sharpLevels.indexOf(size) === -1) {
+        cm.focus();
+        return false;
+    }
     for (var i = startPoint.line; i <= endPoint.line; i++) {
         (function (i) {
             var text = cm.getLine(i);
@@ -1132,14 +1139,20 @@ function _toggleHeading(cm, direction, size) {
             if (direction !== undefined) {
                 if (currHeadingLevel <= 0) {
                     if (direction == 'bigger') {
-                        text = '###### ' + text;
+                        text = '#'.repeat(maxLevel) + ' ' + text;
                     } else {
-                        text = '# ' + text;
+                        text = '#'.repeat(minLevel) + ' ' + text;
                     }
-                } else if (currHeadingLevel == 6 && direction == 'smaller') {
-                    text = text.substr(7);
-                } else if (currHeadingLevel == 1 && direction == 'bigger') {
-                    text = text.substr(2);
+                } else if (currHeadingLevel == maxLevel && direction == 'smaller') {
+                    text = text.substr(maxLevel + 1);
+                } else if (currHeadingLevel == minLevel && direction == 'bigger') {
+                    text = text.substr(minLevel + 1);
+                } else if (sharpLevels.length) {
+                    if (direction == 'bigger') {
+                        text = '#'.repeat(sharpLevels[sharpLevels.indexOf(currHeadingLevel)-1]) + text.replace(/^[#]+/, '' );
+                    } else {
+                        text = '#'.repeat(sharpLevels[sharpLevels.indexOf(currHeadingLevel)+1]) + text.replace(/^[#]+/, '' );
+                    }
                 } else {
                     if (direction == 'bigger') {
                         text = text.substr(1);
@@ -2205,108 +2218,138 @@ EasyMDE.prototype.render = function (el) {
     }
     if (options.parsingConfig.headingLevels) {
         // If the *headingLevels* argument is present, set our custom modifiers
-        var makeBiggerHeadline = function(headline, from, to) {
-            headline = headline || '';
-            if (!from || !to) {
+        var headingMakeBigger = function(heading, from, to) {
+            heading = heading || '';
+            if (!from || !to || from >= to) {
                 return '';
             }
             var level = '';
-            while (from < to) {
-                level += '#';
-                from++;
+            if (!heading.length) {
+                while (from < to) {
+                    level += '#';
+                    from++;
+                }
+                level += ' ';
+                return level;
+            } else {
+                while (to > 0) {
+                    level += '#';
+                    to--;
+                }
+                level += ' ';
+                return /#/.test(heading) ? heading.replace(/^[#]+\s*/, level) : level;
             }
-            level += ' ';
-            return /#/.test(headline) ? headline.replace(/#\s*/, level) : level;
         };
-        var headlineNeedUpdate = function(myCurrHeadline, allowedHeadlingLevels, levelSearchDir) {
-            if (!myCurrHeadline || !allowedHeadlingLevels) {
+        var headingMakeSmaller = function(heading, from, to) {
+            heading = heading || '';
+            if (!from || !to || from <= to) {
+                return '';
+            }
+            var level = '';
+            if (!heading.length) {
+                while (from > to) {
+                    level += '#';
+                    from--;
+                }
+                level += ' ';
+                return level;
+            } else {
+                while (to > 0) {
+                    level += '#';
+                    to--;
+                }
+                level += ' ';
+                return /#/.test(heading) ? heading.replace(/^[#]+\s*/, level) : level;
+            }
+        };
+        var headingNeedUpdate = function(currHeading, allowedHeadingLevels, levelSearchDir) {
+            if (!currHeading || !allowedHeadingLevels) {
                 return false;
             }
-            myCurrHeadline = myCurrHeadline.trim();
-            if (!/^#+/.test(myCurrHeadline)){
+            currHeading = currHeading.trim();
+            if (!/^#+/.test(currHeading)){
                 return false;
             }
-            var currHeadlingLevel = (myCurrHeadline.match(/^([#]+)/g) || [''])[0].length;
-            if (allowedHeadlingLevels.indexOf(currHeadlingLevel) !== -1) {
+            var currHeadingLevel = (currHeading.match(/^([#]+)/g) || [''])[0].length;
+            if (allowedHeadingLevels.indexOf(currHeadingLevel) !== -1) {
                 return false;
             }
             levelSearchDir = levelSearchDir || 'asc';
             var newHeadingLevel = -1, n = 0;
             if (levelSearchDir === 'asc') {
-                while (n < allowedHeadlingLevels.length) {
-                    if (allowedHeadlingLevels[n] > currHeadlingLevel) {
-                        newHeadingLevel = allowedHeadlingLevels[n];
+                while (n < allowedHeadingLevels.length) {
+                    if (allowedHeadingLevels[n] > currHeadingLevel) {
+                        newHeadingLevel = allowedHeadingLevels[n];
                         break;
                     }
                     n++;
                 }
             }
             if (newHeadingLevel < 0) {
-                n = allowedHeadlingLevels.length - 1;
+                n = allowedHeadingLevels.length - 1;
                 while (n > -1) {
-                    if (allowedHeadlingLevels[n] < currHeadlingLevel) {
-                        newHeadingLevel = allowedHeadlingLevels[n];
+                    if (allowedHeadingLevels[n] < currHeadingLevel) {
+                        newHeadingLevel = allowedHeadingLevels[n];
                         break;
                     }
                     n--;
                 }
                 if (levelSearchDir === 'dsc') {
-                    currHeadlingLevel += 1;
+                    currHeadingLevel += 1;
                     if (newHeadingLevel < 0) {
                         newHeadingLevel = 0;
                     }
                 }
             }
-            if (newHeadingLevel < 0 || newHeadingLevel === currHeadlingLevel) {
+            if (newHeadingLevel < 0 || newHeadingLevel === currHeadingLevel) {
                 return false;
             }
             return {
-                from: currHeadlingLevel,
+                from: currHeadingLevel,
                 to: newHeadingLevel,
-                diff: Math.abs(newHeadingLevel - currHeadlingLevel),
+                diff: Math.abs(newHeadingLevel - currHeadingLevel),
             };
         };
-        var checkNewHeadline = function(cm, obj) {
-            var myHeadline = cm.getRange({
+        var headingCheckNew = function(cm, obj) {
+            var currHeading = cm.getRange({
                 line: obj.from.line,
                 ch: 0,
             }, {
                 line: obj.to.line,
                 ch: obj.to.ch,
             });
-            var levels = headlineNeedUpdate(myHeadline, cm.options.backdrop.headingLevels);
-            if (!levels || !levels.from || !levels.to) {
+            var myLevels = headingNeedUpdate(currHeading, cm.options.backdrop.headingLevels);
+            if (!myLevels || !myLevels.from || !myLevels.to) {
                 return false;
             }
             if (obj.from.line === obj.to.line) {
                 // Most simple case when a modification has occured on a single line
-                if (levels.to > levels.from) {
+                if (myLevels.to > myLevels.from) {
                     // Current level is forbidden so we jump to the closest upper level allowed
                     // We only need to reset the sharp numbers with the appropriate value before the modification is applied
-                    obj.text[0] = makeBiggerHeadline('', levels.from, levels.to);
-                }
-                else {
+                    obj.text[0] = headingMakeBigger('', myLevels.from, myLevels.to);
+                } else {
                     // The current level is forbidden and we jump to the closest lower level available
                     // A bit more is needed: we have to cancel the requested update and trigger a replacement with the existing sharp signs
                     obj.cancel();
-                    var newHeadline = '';
-                    while (levels.to > 0) {
-                        newHeadline += '#';
-                        levels.to--;
+                    var newHeading = '';
+                    while (myLevels.to > 0) {
+                        newHeading += '#';
+                        myLevels.to--;
                     }
-                    newHeadline += ' ';
-                    cm.doc.replaceRange(newHeadline, {
+                    newHeading += ' ';
+                    cm.doc.replaceRange(newHeading, {
                         line: obj.from.line,
                         ch: 0,
                     }, {
                         line: obj.to.line,
                         ch: obj.to.ch,
-                    }, myHeadline ); // 4th arguments to keep a trace in the history when possible
+                    }, currHeading ); // 4th arguments to keep a trace in the history when possible
                 }
             }
             return true;
         };
-        var checkExistingHeadline = function(cm, obj) {
+        var headingCheckExisting = function(cm, obj) {
             var myChar = cm.getRange({
                 line: obj.from.line,
                 ch: obj.from.ch,
@@ -2314,9 +2357,8 @@ EasyMDE.prototype.render = function (el) {
                 line: obj.to.line,
                 ch: obj.to.ch + 1,
             });
-            // console.log( '==' + myChar + '==' );
             if (!/\s|#/.test(myChar || '')) {
-                // Don't bother to go further if no headlines were detected
+                // Don't bother to go further if no headling were detected
                 return false;
             }
             if ((obj.from.line === obj.to.line) && obj.text.length === 1) {
@@ -2327,12 +2369,11 @@ EasyMDE.prototype.render = function (el) {
                         return false;
                     }
                     if (!/#/.test(myText)) {
-                        myText = '# ' + myText.trim(); // Wasn't headline
-                    }
-                    else {
+                        myText = '# ' + myText.trim(); // Wasn't heading
+                    } else {
                         myText = myText.replace(/#/, '##'); // Increment one sharp sign
-                    };
-                    myLevels = headlineNeedUpdate(myText, cm.options.backdrop.headingLevels);
+                    }
+                    myLevels = headingNeedUpdate(myText, cm.options.backdrop.headingLevels);
                     if (!myLevels) {
                         return false;
                     }
@@ -2348,7 +2389,7 @@ EasyMDE.prototype.render = function (el) {
                     return true;
                 }
                 else if (/delete/.test(obj.origin) && obj.text[0] === '') {
-                    myLevels = headlineNeedUpdate(myText.replace(/#/, ''), cm.options.backdrop.headingLevels, 'dsc');
+                    myLevels = headingNeedUpdate(myText.replace(/#/, ''), cm.options.backdrop.headingLevels, 'dsc');
                     if (!myLevels) {
                         return false;
                     }
@@ -2378,50 +2419,95 @@ EasyMDE.prototype.render = function (el) {
                 }
             }
         };
+        var headingCheckRow = function(row, cm) {
+            if (!row || !/^#/.test(row.trim())) {
+                return row;
+            }
+            row = row.replace(/^(\s*)#/, '#');
+            var myLevels = headingNeedUpdate(row, cm.options.backdrop.headingLevels);
+            if (!myLevels || !myLevels.from || !myLevels.to) {
+                return row;
+            } else if (myLevels.from < myLevels.to) {
+                return headingMakeBigger(row, myLevels.from, myLevels.to);
+            } else if (myLevels.to < myLevels.from) {
+                return headingMakeSmaller(row, myLevels.from, myLevels.to);
+            }
+            return row;
+        };
         this.codemirror.on('beforeChange', function (cm, obj) {
-            console.log(obj);
-            if (!obj || !obj.from || !obj.to || !obj.text) {
+            // console.log(obj);
+            if (!obj || !obj.from || !obj.to || !obj.text || !obj.text.length) {
                 // Don't go further 'cause a required argument is missing...
                 return false;
             }
-            if ((obj.from.line === obj.to.line) ) {
+            if ((obj.from.line === obj.to.line) && obj.text.length < 2) {
                 if (obj.to.ch > 6) {
                     // No need to trigger a check if we are on the same line at character 7 or upper
-                    // As we are sure the cursor is not inside a range containing a sharp sign
+                    // As we are sure the cursor was not inside a range containing a sharp sign
                     return false;
                 }
-                if (obj.from.ch === 0 && obj.to.ch === 0 && /\s|\b/.test(obj.text[0] || '')) {
-                    // Prevent space at the beginning of the line
+                if (obj.from.ch === 0 && obj.to.ch === 0 && /\s/.test(obj.text[0] || '')) {
+                    // (Force) Prevent space at the beginning of the line
                     obj.cancel();
                     return false;
                 }
             }
-            if (!obj.text.length) {
-                // Just in case
-                return false;
-            }
             if (!obj.origin) {
-                // Just in case
+                // If a modification was triggered by a code and not an human
+                // The origin can be "undefined", so just in case set one.
                 obj.origin = '+none';
             }
             if (/input/.test(obj.origin)) { // Something was added
                 if (obj.text.length === 1 && obj.text[0].length === 1) {
                     // Only one character on one line is being updated
                     if (obj.text[0] === ' ') {
-                        return checkNewHeadline(cm, obj);
-                    }
-                    else if (obj.text[0] === '#') {
-                        return checkExistingHeadline(cm, obj);
-                    }
-                    else {
-                        return false;
+                        return headingCheckNew(cm, obj);
+                    } else if (obj.text[0] === '#') {
+                        return headingCheckExisting(cm, obj);
                     }
                 }
             }
             else if (/delete/.test(obj.origin)) { // Something was removed
                 if (obj.text.length === 1 && !obj.text[0].length) {
                     // Only one character on one line has been removed
-                    return checkExistingHeadline(cm, obj);
+                    return headingCheckExisting(cm, obj);
+                }
+            }
+            if (obj.text.length < 2) {
+                return false;
+            }
+            // Multilines modification like a paste
+            var r;
+            if (obj.from.ch === 0) {
+                // Loop each row and check for headers
+                for (r=0; r<obj.text.length; r++) {
+                    obj.text[r] = headingCheckRow(obj.text[r], cm);
+                }
+            }
+            else if (obj.from.ch > 7) {
+                // We are sure an existing header is not involved
+                // So exclude the first row from the loop
+                for (r=1; r<obj.text.length; r++) {
+                    obj.text[r] = headingCheckRow(obj.text[r], cm);
+                }
+            }
+            else {
+                // We need to check the first row in case an existing header is involved
+                var startText, oldText, newText;
+                for (r=0; r<obj.text.length; r++) {
+                    if (!r) { // First row
+                        startText = cm.getRange({line: obj.from.line, ch: 0}, {line: obj.from.line, ch: obj.from.ch});
+                        if (/#/.test(startText)) {
+                            oldText = startText + obj.text[r];
+                            newText = headingCheckRow(oldText, cm);
+                            if (oldText !== newText) { // A modification has been made
+                                obj.text[r] = newText;
+                                obj.from.ch = 0;
+                            }
+                        }
+                    } else { // 2nd and next rows
+                        obj.text[r] = headingCheckRow(obj.text[r], cm);
+                    }
                 }
             }
         });

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1124,7 +1124,7 @@ function _toggleHeading(cm, direction, size) {
 
     var startPoint = cm.getCursor('start');
     var endPoint = cm.getCursor('end');
-    var sharpLevels = cm.options.backdrop ? (cm.options.backdrop.headingLevels || []) : (cm.mode ? (cm.mode.headingLevels || []) : []),
+    var sharpLevels = cm.options.backdrop ? (cm.options.backdrop.headingLevels || []) : (cm.options.mode ? (cm.options.mode.headingLevels || []) : []),
         minLevel = sharpLevels.length ? sharpLevels[0] : 1,
         maxLevel = sharpLevels.length ? sharpLevels[sharpLevels.length-1] : 6;
     if (size && sharpLevels.length && sharpLevels.indexOf(size) === -1) {
@@ -2318,7 +2318,7 @@ EasyMDE.prototype.render = function (el) {
                 line: obj.to.line,
                 ch: obj.to.ch,
             });
-            var myLevels = headingNeedUpdate(currHeading, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.mode.headingLevels);
+            var myLevels = headingNeedUpdate(currHeading, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels);
             if (!myLevels || !myLevels.from || !myLevels.to) {
                 return false;
             }
@@ -2380,7 +2380,7 @@ EasyMDE.prototype.render = function (el) {
                     } else {
                         myText = myText.replace(/#/, '##'); // Increment one sharp sign
                     }
-                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.mode.headingLevels);
+                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels);
                     if (!myLevels) {
                         return false;
                     }
@@ -2439,7 +2439,7 @@ EasyMDE.prototype.render = function (el) {
                             ch: obj.to.ch + 8,
                         };
                     }
-                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.mode.headingLevels, searchDir);
+                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels, searchDir);
                     if (!myLevels || !myLevels.diff) {
                         return false;
                     }
@@ -2472,7 +2472,7 @@ EasyMDE.prototype.render = function (el) {
                 return row;
             }
             row = row.replace(/^(\s*)#/, '#');
-            var myLevels = headingNeedUpdate(row, cm.mode.headingLevels || cm.options.backdrop.headingLevels);
+            var myLevels = headingNeedUpdate(row, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels);
             if (!myLevels || !myLevels.from || !myLevels.to) {
                 return row;
             } else if (myLevels.from < myLevels.to) {

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1822,7 +1822,15 @@ function EasyMDE(options) {
     options.parsingConfig = extend({
         highlightFormatting: true, // needed for toggleCodeBlock to detect types of code
     }, options.parsingConfig || {});
-
+    if ( options.parsingConfig.headingLevels ) {
+        var headingLevels = [];
+        for ( var l = 0, requestedLevels = options.parsingConfig.headingLevels; l < requestedLevels.length; l++ ) {
+            if ( ! isNaN( requestedLevels[ l ] ) && headingLevels.indexOf( requestedLevels[ l ] ) === -1 ) {
+                headingLevels[ l ] = parseInt( requestedLevels[ l ], 10 );
+            }
+        }
+        options.parsingConfig.headingLevels = headingLevels;
+    }
 
     // Merging the insertTexts, with the given options
     options.insertTexts = extend({}, insertTexts, options.insertTexts || {});
@@ -2188,6 +2196,12 @@ EasyMDE.prototype.render = function (el) {
         var cm = this.codemirror;
         cm.on('change', function () {
             cm.save();
+        });
+    }
+    if (options.parsingConfig.headingLevels) {
+        var cm = this.codemirror;
+        cm.on('beforeChange', function (cm, obj) {
+            console.log( obj );
         });
     }
 

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2546,7 +2546,6 @@ EasyMDE.prototype.render = function (el) {
                                 newText = headingCheckRow(oldText, cm);
                             if (oldText !== newText) { // A modification has been made
                                 obj.text[r] = newText.substring(obj.from.ch);
-                                // obj.from.ch = 0;
                             }
                         }
                     }
@@ -2558,9 +2557,16 @@ EasyMDE.prototype.render = function (el) {
                             line: obj.from.line,
                             ch: obj.from.ch + 8,
                         });
-                        console.log( obj.txt[r] );
-                        console.log( endText );
-                        obj.text[r] = headingCheckRow(obj.text[r], cm);
+                        if (/#/.test(endText)) {
+                            var oldText = obj.text[r] + endText,
+                                newText = headingCheckRow(oldText, cm);
+                            if (oldText !== newText) { // A modification has been made
+                                obj.text[r] = newText.replace(endText, '');
+                            }
+                        }
+                        else {
+                            obj.text[r] = headingCheckRow(obj.text[r], cm);
+                        }
                     }
                     else { // 2nd and next rows
                         obj.text[r] = headingCheckRow(obj.text[r], cm);

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -994,7 +994,7 @@ function toggleSideBySide(editor) {
     }
 
     var sideBySideRenderingFunction = function () {
-        var newValue = editor.options.previewRender(editor.value(), preview);
+        var newValue = editor.options.previewRender(editor.options.markdownFilters.apply_filters(editor.value()), preview);
         if (newValue != null) {
             preview.innerHTML = newValue;
         }
@@ -1005,7 +1005,7 @@ function toggleSideBySide(editor) {
     }
 
     if (useSideBySideListener) {
-        var newValue = editor.options.previewRender(editor.value(), preview);
+        var newValue = editor.options.previewRender(editor.options.markdownFilters.apply_filters(editor.value()), preview);
         if (newValue != null) {
             preview.innerHTML = newValue;
         }
@@ -1074,7 +1074,7 @@ function togglePreview(editor) {
         }
     }
 
-    var preview_result = editor.options.previewRender(editor.value(), preview);
+    var preview_result = editor.options.previewRender(editor.options.markdownFilters.apply_filters(editor.value()), preview);
     if (preview_result !== null) {
         preview.innerHTML = preview_result;
     }
@@ -1821,21 +1821,51 @@ function EasyMDE(options) {
         }
     }
 
-
-    // Add default preview rendering function
-    if (!options.previewRender) {
-        options.previewRender = function (plainText) {
-            // Note: "this" refers to the options object
-            return this.parent.markdown(plainText);
+    // Generic mardown text render filter utility
+    options.markdownFilters = (function(){
+        var registered = {},
+            queue = [];
+        return {
+            add_filter: function(name, fnc) {
+                if (typeof fnc === 'function') {
+                    registered[name] = fnc;
+                    queue.push(name);
+                    return true;
+                }
+                return false;
+            },
+            apply_filter: function(name, text) {
+                if (registered[name] && typeof registered[name] === 'function') {
+                    return registered[name].call(this, text);
+                }
+                return text;
+            },
+            apply_filters: function(text) {
+                if (!queue || !queue.length) {
+                    return text;
+                }
+                for (var q=0,fncs=registered||[],max=queue.length; q<max; q++) {
+                    var idx = queue[q];
+                    if (fncs[idx] && typeof fncs[idx] === 'function') {
+                        text = fncs[idx].call(this, text);
+                    }
+                }
+                return text;
+            },
         };
-    }
+    })();
+    // The markdown module uses tabs as indent. Switch to tabs for the preview to render properly
+    options.markdownFilters.add_filter( 'tab2space', function(text) {
+        var indents = text.match(/\n\s+/g) || [];
+        for (var i=0,tmp; i<indents.length; i++) {
+            tmp = indents[i].replace(' ', '\t');
+            text = text.replace(indents[i], tmp);
+        }
+        return text;
+    });
 
-
-    // Set default options for parsing config
-    options.parsingConfig = extend({
-        highlightFormatting: true, // needed for toggleCodeBlock to detect types of code
-    }, options.parsingConfig || {});
-    if ( options.parsingConfig.headingLevels ) {
+    // Selective headings levels
+    if (options.parsingConfig && options.parsingConfig.headingLevels) {
         var headingLevels = [];
         for ( var l = 0, requestedLevels = options.parsingConfig.headingLevels; l < requestedLevels.length; l++ ) {
             requestedLevels[ l ] = parseInt( requestedLevels[ l ], 10 );
@@ -1848,7 +1878,55 @@ function EasyMDE(options) {
             headingLevels[ l ] = requestedLevels[ l ];
         }
         options.parsingConfig.headingLevels = headingLevels.sort();
+        if (options.parsingConfig.headingLevels.length > 0 && !options.overlayMode) {
+            options.overlayMode = {
+                mode: {
+                    name: 'escsharp-mode',
+                    token: function(stream) {
+                        var ch = stream.peek();
+                        if (ch === '\\') {
+                            stream.next();
+                            ch = stream.peek();
+                            if (ch === '#') {
+                                stream.next();
+                                return 'sharp-escaped';
+                            }
+                        }
+                        stream.next();
+                        return null;
+                    },
+                },
+                combine: true,
+            };
+        }
+        options.markdownFilters.add_filter('sharp_list', function(text){
+            // Quick trick to trigger order list rendering
+            return text.replace(/\\#([^#]{1})/g, '1.$1');
+        });
     }
+
+    // Add default preview rendering function
+    if (!options.previewRender) {
+        if (options.previewRenderedMarkdown) {
+            options.previewRender = function (plainText, preview) {
+                plainText = options.markdownFilters.apply_filters(plainText);
+                return options.previewRenderedMarkdown(this.parent.markdown(plainText), preview);
+            };
+        }
+        else {
+            options.previewRender = function (plainText) {
+                // Note: "this" refers to the options object
+                plainText = options.markdownFilters.apply_filters(plainText);
+                return this.parent.markdown(plainText);
+            };
+        }
+    }
+
+
+    // Set default options for parsing config
+    options.parsingConfig = extend({
+        highlightFormatting: true, // needed for toggleCodeBlock to detect types of code
+    }, options.parsingConfig || {});
 
     // Merging the insertTexts, with the given options
     options.insertTexts = extend({}, insertTexts, options.insertTexts || {});
@@ -2149,9 +2227,14 @@ EasyMDE.prototype.render = function (el) {
         CodeMirror.defineMode('overlay-mode', function (config) {
             return CodeMirror.overlayMode(CodeMirror.getMode(config, options.spellChecker !== false ? 'spell-checker' : 'gfm'), options.overlayMode.mode, options.overlayMode.combine);
         });
-
         mode = 'overlay-mode';
         backdrop = options.parsingConfig;
+        backdrop.name = 'gfm';
+        backdrop.gitHubSpice = false;
+    } else if (options.spellChecker !== false) {
+        mode = 'spell-checker';
+        backdrop = options.parsingConfig;
+        backdrop.name = 'gfm';
         backdrop.gitHubSpice = false;
     } else {
         mode = options.parsingConfig;
@@ -2159,11 +2242,6 @@ EasyMDE.prototype.render = function (el) {
         mode.gitHubSpice = false;
     }
     if (options.spellChecker !== false) {
-        mode = 'spell-checker';
-        backdrop = options.parsingConfig;
-        backdrop.name = 'gfm';
-        backdrop.gitHubSpice = false;
-
         if (typeof options.spellChecker === 'function') {
             options.spellChecker({
                 codeMirrorInstance: CodeMirror,
@@ -2216,7 +2294,7 @@ EasyMDE.prototype.render = function (el) {
             cm.save();
         });
     }
-    if (options.parsingConfig.headingLevels) {
+    if (options.parsingConfig.headingLevels && options.parsingConfig.headingLevels.length) {
         // If the *headingLevels* argument is present, set our custom modifiers
         var headingMakeBigger = function(heading, from, to) {
             heading = heading || '';
@@ -2266,7 +2344,7 @@ EasyMDE.prototype.render = function (el) {
             if (!currHeading || !allowedHeadingLevels) {
                 return false;
             }
-            currHeading = currHeading.trim();
+            // currHeading = currHeading.trim();
             if (!/^#+/.test(currHeading)){
                 return false;
             }
@@ -2318,7 +2396,21 @@ EasyMDE.prototype.render = function (el) {
                 line: obj.to.line,
                 ch: obj.to.ch,
             });
-            var myLevels = headingNeedUpdate(currHeading, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels);
+            var allowedHeadingLevels = cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels;
+            if (allowedHeadingLevels.indexOf('1') === -1 && /input/.test(obj.origin) && obj.from.line === obj.to.line && obj.text.length === 1) {
+                if (/^\s*#$/.test(currHeading) && obj.text[0] === ' ') {
+                    obj.cancel();
+                    cm.doc.replaceRange(currHeading.replace('#','\\# '), {
+                        line: obj.from.line,
+                        ch: 0,
+                    }, {
+                        line: obj.to.line,
+                        ch: obj.to.ch,
+                    });
+                    return false;
+                }
+            }
+            var myLevels = headingNeedUpdate(currHeading, allowedHeadingLevels);
             if (!myLevels || !myLevels.from || !myLevels.to) {
                 return false;
             }
@@ -2350,6 +2442,63 @@ EasyMDE.prototype.render = function (el) {
             return true;
         };
         var headingCheckExisting = function(cm, obj) {
+            var myText,
+                allowedHeadingLevels = cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels;
+            if (allowedHeadingLevels.indexOf('1') === -1 && obj.from.line === obj.to.line && obj.text.length === 1) {
+                myText = cm.getRange({
+                    line: obj.from.line,
+                    ch: 0,
+                }, {
+                    line: obj.to.line,
+                    ch: obj.to.ch,
+                });
+                if (/input/.test(obj.origin || '') ) {
+                    if (/^\s+$/.test(myText) && obj.text[0] === '#') {
+                        obj.cancel();
+                        cm.doc.replaceRange(myText+'\\#', {
+                            line: obj.from.line,
+                            ch: 0,
+                        }, {
+                            line: obj.to.line,
+                            ch: obj.to.ch,
+                        });
+                        return false;
+                    }
+                    else if (myText === '' && obj.text[0] === '#') {
+                        obj.cancel();
+                        cm.doc.replaceRange('\\#', {
+                            line: obj.from.line,
+                            ch: 0,
+                        }, {
+                            line: obj.to.line,
+                            ch: obj.to.ch,
+                        });
+                        return false;
+                    }
+                    else if (/^\s*\\#$/.test(myText) && obj.text[0] === '#') {
+                        obj.cancel();
+                        cm.doc.replaceRange(myText.replace('\\', '') + '#', {
+                            line: obj.from.line,
+                            ch: 0,
+                        }, {
+                            line: obj.to.line,
+                            ch: obj.to.ch,
+                        });
+                        return false;
+                    }
+                }
+                else if (/delete/.test(obj.origin || '') && /^\s*\\#$/.test(myText) && obj.text[0] === '') {
+                    obj.cancel();
+                    cm.doc.replaceRange(myText.replace('\\#',''), {
+                        line: obj.from.line,
+                        ch: 0,
+                    }, {
+                        line: obj.to.line,
+                        ch: obj.to.ch,
+                    });
+                    return false;
+                }
+            }
             var myChar = cm.getRange({
                 line: obj.from.line,
                 ch: obj.from.ch,
@@ -2358,29 +2507,29 @@ EasyMDE.prototype.render = function (el) {
                 ch: obj.to.ch + 1,
             });
             if (!/\s|#/.test(myChar || '')) {
-                // Don't bother to go further if no headling were detected
+                // Don't bother to go further if no heading were detected
                 return false;
             }
             if ((obj.from.line === obj.to.line) && obj.text.length < 2) {
-                var myLevels, myText;
+                var myLevels;
+                myText = cm.getRange({
+                    line: obj.from.line,
+                    ch: 0,
+                }, {
+                    line: obj.to.line,
+                    ch: 8,
+                });
                 if (/input/.test(obj.origin) && obj.text[0] === '#') {
                     if (!/[^\s#]/.test(myText)) {
                         // Newly created, skip the check for now
                         return false;
                     }
-                    myText = cm.getRange({
-                        line: obj.from.line,
-                        ch: 0,
-                    }, {
-                        line: obj.to.line,
-                        ch: 8,
-                    });
                     if (!/#/.test(myText)) {
                         myText = '# ' + myText.trim(); // Wasn't heading
                     } else {
                         myText = myText.replace(/#/, '##'); // Increment one sharp sign
                     }
-                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels);
+                    myLevels = headingNeedUpdate(myText, allowedHeadingLevels);
                     if (!myLevels) {
                         return false;
                     }
@@ -2439,7 +2588,7 @@ EasyMDE.prototype.render = function (el) {
                             ch: obj.to.ch + 8,
                         };
                     }
-                    myLevels = headingNeedUpdate(myText, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels, searchDir);
+                    myLevels = headingNeedUpdate(myText, allowedHeadingLevels, searchDir);
                     if (!myLevels || !myLevels.diff) {
                         return false;
                     }
@@ -2471,7 +2620,7 @@ EasyMDE.prototype.render = function (el) {
             if (!row || !/^#/.test(row.trim())) {
                 return row;
             }
-            row = row.replace(/^(\s*)#/, '#');
+            // row = row.replace(/^(\s*)#/, '#');
             var myLevels = headingNeedUpdate(row, cm.options.backdrop ? cm.options.backdrop.headingLevels : cm.options.mode.headingLevels);
             if (!myLevels || !myLevels.from || !myLevels.to) {
                 return row;
@@ -2499,11 +2648,13 @@ EasyMDE.prototype.render = function (el) {
                     // As we are sure the cursor was not inside a range containing a sharp sign
                     return false;
                 }
+                /*
                 if (obj.from.ch === 0 && obj.to.ch === 0 && /\s/.test(obj.text[0] || '')) {
                     // (Force) Prevent space at the beginning of the line
                     obj.cancel();
                     return false;
                 }
+                */
                 if (/input/.test(obj.origin)) { // Something was added
                     if (obj.text.length === 1 && obj.text[0].length === 1) {
                         // Only one character on one line is being updated
@@ -2619,6 +2770,71 @@ EasyMDE.prototype.render = function (el) {
                 }
             }
         });
+        if (options.parsingConfig.headingLevels.indexOf(1) === -1) {
+            // Modify the cursor behavior to avoid being in the middle of \# (|\# {->} \#| or \#| {<-} |\#)
+            // Thanks to https://stackoverflow.com/questions/32622128/codemirror-how-to-read-editor-text-before-or-after-cursor-position
+            this.codemirror.on('cursorActivity', function(cm) {
+                var currCursor = cm.doc.getCursor(),
+                    line = currCursor.line,
+                    ch = currCursor.ch,
+                    cursorString = cm.doc.getLine(line).substr(Math.max(ch-1,0),2);
+                if (cursorString === '\\#' && currCursor.sticky) {
+                    if (currCursor.sticky === 'after') {
+                        cm.focus();
+                        cm.doc.setCursor({
+                            line: line,
+                            ch: Math.max(ch-1,0),
+                        });
+                    }
+                    else if (currCursor.sticky === 'before') {
+                        cm.focus();
+                        cm.doc.setCursor({
+                            line: line,
+                            ch: ch+1,
+                        });
+                    }
+                }
+            });
+            // Make the \# sharp combo behaves as a list
+            this.codemirror.on('keyHandled', function(cm, kn, ev) {
+                if (!kn || kn !== 'Enter' || !ev) {
+                    return true;
+                }
+                var currCursor = cm.doc.getCursor(),
+                    prevLine = currCursor.line - 1;
+                if (prevLine < 0) {
+                    return true;
+                }
+                var prevText = cm.getRange({
+                    line: prevLine,
+                    ch: 0,
+                }, {
+                    line: prevLine,
+                    ch: 20,
+                });
+                if (/^[ ]*\\#[ ]*/.test(prevText)) {
+                    var newTextLine = prevText.match(/^[ ]*\\#[ ]*/)[0];
+                    cm.doc.replaceRange(newTextLine, {
+                        line: currCursor.line,
+                        ch: 0,
+                    }, {
+                        line: currCursor.line,
+                        ch: newTextLine.length,
+                    });
+                } else if (/^ +/.test(prevText)) {
+                    var spaces = prevText.match(/ +/);
+                    if (spaces.length) {
+                        cm.doc.replaceRange(' '.repeat(spaces.length), {
+                            line: currCursor.line,
+                            ch: 0,
+                        }, {
+                            line: currCursor.line,
+                            ch: 0 + spaces.length,
+                        });
+                    }
+                }
+            });
+        }
     }
 
     this.gui = {};
@@ -3298,6 +3514,7 @@ EasyMDE.prototype.value = function (val) {
         if (this.isPreviewActive()) {
             var wrapper = cm.getWrapperElement();
             var preview = wrapper.lastChild;
+            val = this.options.markdownFilters.apply_filters(val);
             var preview_result = this.options.previewRender(val, preview);
             if (preview_result !== null) {
                 preview.innerHTML = preview_result;


### PR DESCRIPTION
Greetings @Ionaru and other EasyMDE developers,

Pierre-Henri alias Peter here, the french fry guy behind WordPress Markup Markdown, a WordPressified working version of EasyMDE 😁 First, congratulations for having the gut to code the project. It's a great piece of work that probably required  a consequent amount of time and energy 👏 I wouldn't have been able to do it myself.

For my first contribution, similar to the environment described in issue #354 ,  I was looking for a way to disable the H1 tag as WordPress has already its own post title field by default. Actually it was far more complicated than I thought... 🥵

It's a work in progress but this version is usable at least. What I did is basically adding a new option to specify heading levels, and then using the CodeMirror _beforeChange_ event to do some magic to modify the update if need be. Nothing amazing, I mostly prevent the user inputting some characters by tuning the output.

I have no idea if it's a match for you in a future release, any feedback is welcome, especially if we can collaborate on a few features 🤲

Kind regards, and have a wonderful day

Peter