### PR TITLE
Hotfix: Patching Overlay Mode

### DIFF
--- a/example/index_customOverlay.html
+++ b/example/index_customOverlay.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Example / Preview / sideBySideFullscreen : false</title>
+    <link rel="stylesheet" href="../dist/easymde.min.css">
+    <script src="../dist/easymde.min.js"></script>
+    <style type="text/css">.cm-a-char { color: #00F !important; }</style>
+</head>
+
+<body>
+    <textarea># Good day to you Ionaru !
+
+Every  "A" character will be colored in blue !
+
+## Awesome Markdown Editor
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ut pretium lorem. Proin fringilla eros sit amet ex aliquet interdum. Sed fermentum facilisis neque at commodo. Sed ornare dictum nisl quis bibendum. Sed venenatis eros turpis, imperdiet luctus mauris efficitur ut. Nunc eget orci orci. Nunc eu dolor tincidunt, porta odio vitae, rhoncus elit. Suspendisse at nisl dui. Aenean purus magna, convallis sit amet varius in, tincidunt eu libero.
+
+## Super Action Letters
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ut pretium lorem. Proin fringilla eros sit amet ex aliquet interdum. Sed fermentum facilisis neque at commodo. Sed ornare dictum nisl quis bibendum. Sed venenatis eros turpis, imperdiet luctus mauris efficitur ut. Nunc eget orci orci. Nunc eu dolor tincidunt, porta odio vitae, rhoncus elit. Suspendisse at nisl dui. Aenean purus magna, convallis sit amet varius in, tincidunt eu libero.</textarea>
+    <script>
+        const easyMDE = new EasyMDE({
+            sideBySideFullscreen: false,
+            overlayMode: {
+                mode: {
+                    name: 'test-mode',
+                    token: function(stream) {
+                        if ('A' === (stream.peek() || '')) {
+                            stream.next();
+                            return 'a-char';
+                        }
+                        stream.next();
+                        return null;
+                    }
+                }
+            }
+        });
+        easyMDE.codemirror.focus();
+        easyMDE.codemirror.doc.replaceRange(' ', {line: 2, ch: 47}, {line: 2, ch: 48});
+        easyMDE.codemirror.doc.setCursor({line: 2, ch: 48});
+    </script>
+</body>
+
+</html>

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2123,9 +2123,14 @@ EasyMDE.prototype.render = function (el) {
         CodeMirror.defineMode('overlay-mode', function (config) {
             return CodeMirror.overlayMode(CodeMirror.getMode(config, options.spellChecker !== false ? 'spell-checker' : 'gfm'), options.overlayMode.mode, options.overlayMode.combine);
         });
-
         mode = 'overlay-mode';
         backdrop = options.parsingConfig;
+        backdrop.name = 'gfm';
+        backdrop.gitHubSpice = false;
+    } else if (options.spellChecker !== false) {
+        mode = 'spell-checker';
+        backdrop = options.parsingConfig;
+        backdrop.name = 'gfm';
         backdrop.gitHubSpice = false;
     } else {
         mode = options.parsingConfig;
@@ -2133,11 +2138,6 @@ EasyMDE.prototype.render = function (el) {
         mode.gitHubSpice = false;
     }
     if (options.spellChecker !== false) {
-        mode = 'spell-checker';
-        backdrop = options.parsingConfig;
-        backdrop.name = 'gfm';
-        backdrop.gitHubSpice = false;
-
         if (typeof options.spellChecker === 'function') {
             options.spellChecker({
                 codeMirrorInstance: CodeMirror,


### PR DESCRIPTION
Greetings @Ionaru 

This feedback is about a bug fix I guess.

I'm not a rock star with CodeMirror combined modes and tokens stuff so my patch might not be relevant at all - in this case sorry in advance 😝- from what I understand with the the current options, the custom `overlay-mode` is overwritten by the `spell-checker` mode - so disabled actually 😅- if the spell checker is set to true. 

It's about an _if / else_ snippet so there are various ways to patch it... And damage other setups if not done properly 💦
This patch works for me. Feel free to check and play with the demo page. 😉

Best regards,

Peter

