### PR TITLE
chore: adjust the regex for previewing images so that it only attempts to render if the image has a bracket immediately preceding the parentheses

### DIFF
--- a/cypress/e2e/4.image-rendering/image-rendering.cy.js
+++ b/cypress/e2e/4.image-rendering/image-rendering.cy.js
@@ -1,0 +1,43 @@
+/// <reference types="cypress" />
+
+describe('Image rendering', () => {
+
+    const imageUrl = 'https://picsum.photos/id/237/150';
+
+    beforeEach(() => {
+        cy.visit(__dirname + '/index.html');
+        cy.intercept('GET', imageUrl).as('image');
+    });
+
+    it('must render an image inside the editor', () => {
+        cy.get('.EasyMDEContainer').should('be.visible');
+        cy.get('#textarea').should('not.be.visible');
+
+        cy.get('.EasyMDEContainer .CodeMirror').type(imageUrl);
+        cy.get('.EasyMDEContainer .CodeMirror').type('{home}![Dog!]({end})');
+
+        cy.wait('@image');
+
+        cy.get(`.EasyMDEContainer [data-img-src="${imageUrl}"]`).should('be.visible');
+
+        cy.previewOn();
+
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', `<p><img src="${imageUrl}" alt="Dog!"></p>`);
+    });
+
+    it('must be able to handle parentheses inside image alt text', () => {
+        cy.get('.EasyMDEContainer').should('be.visible');
+        cy.get('#textarea').should('not.be.visible');
+
+        cy.get('.EasyMDEContainer .CodeMirror').type(imageUrl);
+        cy.get('.EasyMDEContainer .CodeMirror').type('{home}![Dog! (He\'s a good boy!)]({end})');
+
+        cy.wait('@image');
+
+        cy.get(`.EasyMDEContainer [data-img-src="${imageUrl}"]`).should('be.visible');
+
+        cy.previewOn();
+
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', `<p><img src="${imageUrl}" alt="Dog! (He's a good boy!)"></p>`);
+    });
+});

--- a/cypress/e2e/4.image-rendering/index.html
+++ b/cypress/e2e/4.image-rendering/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Default</title>
+    <link rel="stylesheet" href="../../../dist/easymde.min.css">
+    <script src="../../../dist/easymde.min.js"></script>
+</head>
+
+<body>
+    <textarea id="textarea"></textarea>
+    <script>
+        const easyMDE = new EasyMDE({
+            previewImagesInEditor: true,
+        });
+    </script>
+</body>
+
+</html>

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -2251,7 +2251,7 @@ EasyMDE.prototype.render = function (el) {
                 return;
             }
             if (!parentEl.hasAttribute('data-img-src')) {
-                var srcAttr = parentEl.innerText.match('\\((.*)\\)'); // might require better parsing according to markdown spec
+                var srcAttr = parentEl.innerText.match(/!\[.*?\]\((.*?)\)/); // might require better parsing according to markdown spec
                 if (!window.EMDEimagesCache) {
                     window.EMDEimagesCache = {};
                 }


### PR DESCRIPTION
## Problem
When the alt of an image has parentheses inside of it and `previewImagesInEditor` is `true`, the editor tries to render the image by making a GET with everything thats after the opening parentheses, e.g.:
```md
![My alt (that has a parentheses)](my image url)
```
it tries to do a GET using the base url of the site + that has a parentheses)](my image url) and **it results in a 404 error**
Example:
```http://localhost:8000/that%20has%20a%20parentheses)](my%20image%20url```
## Solution
 in this PR i just fixed the regex that was used to match the src of an image 😄 