### PR TITLE
chore: update actions to v4

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: current
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: npm audit --omit=dev
 
@@ -36,25 +36,25 @@ jobs:
         node-version: [ '14', '16', '18' ]
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: npm ci
 
       - name: Test
         run: npm test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           retention-days: 7
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos
@@ -68,11 +68,11 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: current
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: npm ci
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -50,14 +50,14 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots-nodejs-${{ matrix.node-version }}
           path: cypress/screenshots
           retention-days: 7
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos
+          name: cypress-videos-nodejs-${{ matrix.node-version }}
           path: cypress/videos
           retention-days: 7
 


### PR DESCRIPTION
## Problem
I opened a PR (https://github.com/Ionaru/easy-markdown-editor/pull/608), but the CI seems to be failing because actions v3 is deprecated. [The actions documentation recommends using v4 instead](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).


## Solution
In this PR, I updated the action configuration to use the v4 version. If there's anything else I can do, please let me know 😄