### PR TITLE
Make it more clear how to use native spell checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ easyMDE.value('New input for **EasyMDE**');
 - **showIcons**: An array of icon names to show. Can be used to show specific icons hidden by default without completely customizing the toolbar.
 - **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.  Optionally pass a CodeMirrorSpellChecker-compliant function.
 - **inputStyle**: `textarea` or `contenteditable`. Defaults to `textarea` for desktop and `contenteditable` for mobile. `contenteditable` option is necessary to enable nativeSpellcheck.
-- **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`. Only works when `inputStyle` is set to `contenteditable`
+- **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`. Only works when `inputStyle` is set to `contenteditable` and spellChecker is set to `false`.
 - **sideBySideFullscreen**: If set to `false`, allows side-by-side editing without going into fullscreen. Defaults to `true`.
 - **status**: If set to `false`, hide the status bar. Defaults to the array of built-in status bar items.
   - Optionally, you can set an array of status bar items to include, and in what order. You can even define your own custom status bar items.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ easyMDE.value('New input for **EasyMDE**');
 - **showIcons**: An array of icon names to show. Can be used to show specific icons hidden by default without completely customizing the toolbar.
 - **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.  Optionally pass a CodeMirrorSpellChecker-compliant function.
 - **inputStyle**: `textarea` or `contenteditable`. Defaults to `textarea` for desktop and `contenteditable` for mobile. `contenteditable` option is necessary to enable nativeSpellcheck.
-- **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`. Only works when `inputStyle` is set to `contenteditable` and spellChecker is set to `false`.
+- **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`. Only works when `inputStyle` is set to `contenteditable` and `spellChecker` is set to `false`.
 - **sideBySideFullscreen**: If set to `false`, allows side-by-side editing without going into fullscreen. Defaults to `true`.
 - **status**: If set to `false`, hide the status bar. Defaults to the array of built-in status bar items.
   - Optionally, you can set an array of status bar items to include, and in what order. You can even define your own custom status bar items.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ easyMDE.value('New input for **EasyMDE**');
 - **showIcons**: An array of icon names to show. Can be used to show specific icons hidden by default without completely customizing the toolbar.
 - **spellChecker**: If set to `false`, disable the spell checker. Defaults to `true`.  Optionally pass a CodeMirrorSpellChecker-compliant function.
 - **inputStyle**: `textarea` or `contenteditable`. Defaults to `textarea` for desktop and `contenteditable` for mobile. `contenteditable` option is necessary to enable nativeSpellcheck.
-- **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`.
+- **nativeSpellcheck**: If set to `false`, disable native spell checker. Defaults to `true`. Only works when `inputStyle` is set to `contenteditable`
 - **sideBySideFullscreen**: If set to `false`, allows side-by-side editing without going into fullscreen. Defaults to `true`.
 - **status**: If set to `false`, hide the status bar. Defaults to the array of built-in status bar items.
   - Optionally, you can set an array of status bar items to include, and in what order. You can even define your own custom status bar items.


### PR DESCRIPTION
To use the native browser built-in spellchecker you need to set the spellchecker to false AND you need to set inputstyle to be contenteditable. This wasn't clear to me and some others, see #617

This PR adds even more info to help users use the native spell check.