### PR TITLE
Allow translations of button tooltips

### DIFF
--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -209,7 +209,7 @@ function createToolbarButton(options, enableActions, enableTooltips, shortcuts, 
     }
 
     if (options.title && enableTooltips) {
-        el.title = createTooltip(options.title, options.action, shortcuts);
+        el.title = createTooltip(options.title, options.action, shortcuts, parent.options.translations, parent.options.language);
 
         if (isMac) {
             el.title = el.title.replace('Ctrl', '⌘');
@@ -289,9 +289,16 @@ function createSep() {
     return el;
 }
 
-function createTooltip(title, action, shortcuts) {
+var translate = function (key, translations, language) {
+    if (translations && language && translations[language] && translations[language][key]) {
+        return translations[language][key];
+    }
+    return key;
+};
+
+function createTooltip(title, action, shortcuts, translations, language) {
     var actionName;
-    var tooltip = title;
+    var tooltip = translate(title, translations, language);
 
     if (action) {
         actionName = getBindingName(action);


### PR DESCRIPTION
This is a non-breaking change that allows to pass in `translations` and a wanted `language` as parameters to `EasyMDE()` in order to translate the toolbar buttons' titles that show up as tooltips. The code uses a simple `replace()` call, so the translation keys must exactly match the default english strings (including letter case, white spaces, etc.) to have the translations be applied.

Example:

```
const easymde = new EasyMDE({
    language: 'de',
    translations: {
        de: {
            'Create Link': 'Link einfügen',
        },
    },
});
```

If no `language` or `translation` was specified, or if no matching translation was found, then the original english string is used.