### PR TITLE
add check-list; switch between unordered-list/ordered-list/check-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # EasyMDE Changelog
 All notable changes to EasyMDE will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Check-list toolbar button and the ability to switch between unordered, ordered, and check-list types (Thanks to [@steve3ussr], [#631]).
+
+### Fixed
+- Extra space added before list content when switching between unordered and ordered lists (Thanks to [@steve3ussr], [#631]).
+
 ## [2.20.0] - 2025-03-04
 ### Added
 - Support for `marked` extensions (Thanks to [@codingjoe], [#611], [#514]).
@@ -295,6 +301,7 @@ Project forked from [SimpleMDE](https://github.com/sparksuite/simplemde-markdown
 [#9]: https://github.com/Ionaru/easy-markdown-editor/issues/9
 
 <!-- Linked PRs -->
+[#631]: https://github.com/Ionaru/easy-markdown-editor/pull/631
 [#608]: https://github.com/Ionaru/easy-markdown-editor/pull/608
 [#592]: https://github.com/Ionaru/easy-markdown-editor/pull/592
 [#591]: https://github.com/Ionaru/easy-markdown-editor/pull/591
@@ -445,6 +452,7 @@ Project forked from [SimpleMDE](https://github.com/sparksuite/simplemde-markdown
 [@p1gp1g]: https://github.com/p1gp1g
 [@mayraamaral]: https://github.com/mayraamaral
 [@codingjoe]: https://github.com/codingjoe
+[@steve3ussr]: https://github.com/steve3ussr
 
 <!-- Linked versions -->
 [Unreleased]: https://github.com/Ionaru/easy-markdown-editor/compare/2.20.0...HEAD

--- a/cypress/e2e/6-list-toggle/index-dash.html
+++ b/cypress/e2e/6-list-toggle/index-dash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>List Toggle (dash bullet)</title>
+    <link rel="stylesheet" href="../../../dist/easymde.min.css">
+    <script src="../../../dist/easymde.min.js"></script>
+</head>
+
+<body>
+    <textarea id="textarea"></textarea>
+    <script>
+        window.easyMDE = new EasyMDE({ unorderedListStyle: '-' });
+    </script>
+</body>
+
+</html>

--- a/cypress/e2e/6-list-toggle/index.html
+++ b/cypress/e2e/6-list-toggle/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>List Toggle</title>
+    <link rel="stylesheet" href="../../../dist/easymde.min.css">
+    <script src="../../../dist/easymde.min.js"></script>
+</head>
+
+<body>
+    <textarea id="textarea"></textarea>
+    <script>
+        window.easyMDE = new EasyMDE();
+    </script>
+</body>
+
+</html>

--- a/cypress/e2e/6-list-toggle/list-toggle.cy.js
+++ b/cypress/e2e/6-list-toggle/list-toggle.cy.js
@@ -64,6 +64,18 @@ describe('List toggle (default unordered bullet *)', () => {
             expectValue('1. foo');
         });
 
+        // Bold + ordered list — exercises the path where `getState` returns multiple
+        // keys (bold + ordered-list). Cursor placed inside the bold content so both
+        // are detected. Output captured from master verbatim.
+        it('"1. **foo**" + unordered → "*  **foo**" (bold + #92 path, double space)', () => {
+            cy.window().then((win) => {
+                win.easyMDE.value('1. **foo**');
+                win.easyMDE.codemirror.setCursor({ line: 0, ch: 6 });
+            });
+            cy.get('button.unordered-list').click();
+            expectValue('*  **foo**');
+        });
+
         // Master quirk: indent is NOT preserved — "* " is prepended in front, leaving
         // the original whitespace after the marker. Locked in as-is.
         it('indented plain line + unordered → "*     foo" (indent moves after marker)', () => {

--- a/cypress/e2e/6-list-toggle/list-toggle.cy.js
+++ b/cypress/e2e/6-list-toggle/list-toggle.cy.js
@@ -48,14 +48,10 @@ describe('List toggle (default unordered bullet *)', () => {
             expectValue('foo');
         });
 
-        // Master quirk: the issue #92 strip leaves a leading space, then `_toggle`
-        // re-prepends "* " producing a double space. Locked in verbatim — the PR
-        // explicitly tries to fix this; the test will fail if/when it does, prompting
-        // a deliberate decision rather than a silent change.
-        it('"1. foo" + unordered → "*  foo" (issue #92 path, double space)', () => {
+        it('"1. foo" + unordered → "* foo"', () => {
             seed('1. foo');
             cy.get('button.unordered-list').click();
-            expectValue('*  foo');
+            expectValue('* foo');
         });
 
         it('"* foo" + ordered → "1. foo"', () => {
@@ -66,14 +62,14 @@ describe('List toggle (default unordered bullet *)', () => {
 
         // Bold + ordered list — exercises the path where `getState` returns multiple
         // keys (bold + ordered-list). Cursor placed inside the bold content so both
-        // are detected. Output captured from master verbatim.
-        it('"1. **foo**" + unordered → "*  **foo**" (bold + #92 path, double space)', () => {
+        // are detected.
+        it('"1. **foo**" + unordered → "* **foo**" (bold + ordered)', () => {
             cy.window().then((win) => {
                 win.easyMDE.value('1. **foo**');
                 win.easyMDE.codemirror.setCursor({ line: 0, ch: 6 });
             });
             cy.get('button.unordered-list').click();
-            expectValue('*  **foo**');
+            expectValue('* **foo**');
         });
 
         // Master quirk: indent is NOT preserved — "* " is prepended in front, leaving
@@ -100,12 +96,11 @@ describe('List toggle (default unordered bullet *)', () => {
             expectValue('1. a\n2. b\n3. c');
         });
 
-        // Master quirk: same double-space as the single-line #92 case, repeated per line.
-        it('ordered → unordered swaps markers (double-space quirk per line)', () => {
+        it('ordered → unordered swaps markers', () => {
             seed('1. a\n2. b\n3. c');
             selectAll();
             cy.get('button.unordered-list').click();
-            expectValue('*  a\n*  b\n*  c');
+            expectValue('* a\n* b\n* c');
         });
 
         it('unordered → ordered renumbers', () => {
@@ -113,6 +108,92 @@ describe('List toggle (default unordered bullet *)', () => {
             selectAll();
             cy.get('button.ordered-list').click();
             expectValue('1. a\n2. b\n3. c');
+        });
+    });
+});
+
+describe('Check-list toggle', () => {
+    beforeEach(() => {
+        cy.visit(__dirname + '/index.html');
+    });
+
+    describe('single line', () => {
+        it('plain line + check-list → "- [ ] foo"', () => {
+            seed('foo');
+            cy.get('button.check-list').click();
+            expectValue('- [ ] foo');
+        });
+
+        it('"- [ ] foo" + check-list toggles off → "foo"', () => {
+            seed('- [ ] foo');
+            cy.get('button.check-list').click();
+            expectValue('foo');
+        });
+
+        it('"- [x] foo" + check-list toggles off → "foo" (checked variant)', () => {
+            seed('- [x] foo');
+            cy.get('button.check-list').click();
+            expectValue('foo');
+        });
+
+        it('"- [X] foo" + check-list toggles off → "foo" (uppercase X variant)', () => {
+            seed('- [X] foo');
+            cy.get('button.check-list').click();
+            expectValue('foo');
+        });
+
+        it('"* foo" + check-list → "- [ ] foo"', () => {
+            seed('* foo');
+            cy.get('button.check-list').click();
+            expectValue('- [ ] foo');
+        });
+
+        it('"1. foo" + check-list → "- [ ] foo"', () => {
+            seed('1. foo');
+            cy.get('button.check-list').click();
+            expectValue('- [ ] foo');
+        });
+
+        it('"- [ ] foo" + unordered → "* foo"', () => {
+            seed('- [ ] foo');
+            cy.get('button.unordered-list').click();
+            expectValue('* foo');
+        });
+
+        it('"- [ ] foo" + ordered → "1. foo"', () => {
+            seed('- [ ] foo');
+            cy.get('button.ordered-list').click();
+            expectValue('1. foo');
+        });
+    });
+
+    describe('multi-line (3 lines, select all)', () => {
+        it('plain → check-list prefixes each line', () => {
+            seed('a\nb\nc');
+            selectAll();
+            cy.get('button.check-list').click();
+            expectValue('- [ ] a\n- [ ] b\n- [ ] c');
+        });
+
+        it('unordered → check-list swaps markers', () => {
+            seed('* a\n* b\n* c');
+            selectAll();
+            cy.get('button.check-list').click();
+            expectValue('- [ ] a\n- [ ] b\n- [ ] c');
+        });
+
+        it('ordered → check-list swaps markers', () => {
+            seed('1. a\n2. b\n3. c');
+            selectAll();
+            cy.get('button.check-list').click();
+            expectValue('- [ ] a\n- [ ] b\n- [ ] c');
+        });
+
+        it('check-list → unordered swaps markers', () => {
+            seed('- [ ] a\n- [ ] b\n- [ ] c');
+            selectAll();
+            cy.get('button.unordered-list').click();
+            expectValue('* a\n* b\n* c');
         });
     });
 });

--- a/cypress/e2e/6-list-toggle/list-toggle.cy.js
+++ b/cypress/e2e/6-list-toggle/list-toggle.cy.js
@@ -1,0 +1,118 @@
+/// <reference types="cypress" />
+
+// Seed value and place cursor at end of first line. Cursor inside list content is
+// required for `getState` to identify the list token type — at column 0 the token
+// is empty and the toggle falls into the wrong branch.
+const seed = (text) =>
+    cy.window().then((win) => {
+        win.easyMDE.value(text);
+        const firstLine = text.split('\n')[0];
+        win.easyMDE.codemirror.setCursor({ line: 0, ch: firstLine.length });
+    });
+
+const selectAll = () =>
+    cy.window().then((win) => win.easyMDE.codemirror.execCommand('selectAll'));
+
+const expectValue = (expected) =>
+    cy.window().should((win) => {
+        expect(win.easyMDE.value()).to.eq(expected);
+    });
+
+describe('List toggle (default unordered bullet *)', () => {
+    beforeEach(() => {
+        cy.visit(__dirname + '/index.html');
+    });
+
+    describe('single line', () => {
+        it('plain line + unordered → "* foo"', () => {
+            seed('foo');
+            cy.get('button.unordered-list').click();
+            expectValue('* foo');
+        });
+
+        it('plain line + ordered → "1. foo"', () => {
+            seed('foo');
+            cy.get('button.ordered-list').click();
+            expectValue('1. foo');
+        });
+
+        it('"* foo" + unordered toggles off → "foo"', () => {
+            seed('* foo');
+            cy.get('button.unordered-list').click();
+            expectValue('foo');
+        });
+
+        it('"1. foo" + ordered toggles off → "foo"', () => {
+            seed('1. foo');
+            cy.get('button.ordered-list').click();
+            expectValue('foo');
+        });
+
+        // Master quirk: the issue #92 strip leaves a leading space, then `_toggle`
+        // re-prepends "* " producing a double space. Locked in verbatim — the PR
+        // explicitly tries to fix this; the test will fail if/when it does, prompting
+        // a deliberate decision rather than a silent change.
+        it('"1. foo" + unordered → "*  foo" (issue #92 path, double space)', () => {
+            seed('1. foo');
+            cy.get('button.unordered-list').click();
+            expectValue('*  foo');
+        });
+
+        it('"* foo" + ordered → "1. foo"', () => {
+            seed('* foo');
+            cy.get('button.ordered-list').click();
+            expectValue('1. foo');
+        });
+
+        // Master quirk: indent is NOT preserved — "* " is prepended in front, leaving
+        // the original whitespace after the marker. Locked in as-is.
+        it('indented plain line + unordered → "*     foo" (indent moves after marker)', () => {
+            seed('    foo');
+            cy.get('button.unordered-list').click();
+            expectValue('*     foo');
+        });
+    });
+
+    describe('multi-line (3 lines, select all)', () => {
+        it('plain → unordered prefixes each line', () => {
+            seed('a\nb\nc');
+            selectAll();
+            cy.get('button.unordered-list').click();
+            expectValue('* a\n* b\n* c');
+        });
+
+        it('plain → ordered numbers each line', () => {
+            seed('a\nb\nc');
+            selectAll();
+            cy.get('button.ordered-list').click();
+            expectValue('1. a\n2. b\n3. c');
+        });
+
+        // Master quirk: same double-space as the single-line #92 case, repeated per line.
+        it('ordered → unordered swaps markers (double-space quirk per line)', () => {
+            seed('1. a\n2. b\n3. c');
+            selectAll();
+            cy.get('button.unordered-list').click();
+            expectValue('*  a\n*  b\n*  c');
+        });
+
+        it('unordered → ordered renumbers', () => {
+            seed('* a\n* b\n* c');
+            selectAll();
+            cy.get('button.ordered-list').click();
+            expectValue('1. a\n2. b\n3. c');
+        });
+    });
+});
+
+describe('List toggle (configured unorderedListStyle: "-")', () => {
+    beforeEach(() => {
+        cy.visit(__dirname + '/index-dash.html');
+    });
+
+    it('plain line + unordered uses configured "-" bullet', () => {
+        seed('foo');
+        cy.get('button.unordered-list').click();
+        expectValue('- foo');
+    });
+});

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -30,6 +30,7 @@ var bindings = {
     'toggleBlockquote': toggleBlockquote,
     'toggleOrderedList': toggleOrderedList,
     'toggleUnorderedList': toggleUnorderedList,
+    'toggleCheckList': toggleCheckList,
     'toggleCodeBlock': toggleCodeBlock,
     'togglePreview': togglePreview,
     'toggleStrikethrough': toggleStrikethrough,
@@ -323,6 +324,8 @@ function getState(cm, pos) {
             text = cm.getLine(pos.line);
             if (/^\s*\d+\.\s/.test(text)) {
                 ret['ordered-list'] = true;
+            } else if (/^\s*- \[[ xX]]\s/.test(text)) {
+                ret['check-list'] = true;
             } else {
                 ret['unordered-list'] = true;
             }
@@ -811,6 +814,10 @@ function toggleOrderedList(editor) {
     _toggleLine(editor.codemirror, 'ordered-list');
 }
 
+function toggleCheckList(editor) {
+    _toggleLine(editor.codemirror, 'check-list');
+}
+
 /**
  * Action for clean block (remove headline, list, blockquote code, markers)
  */
@@ -1184,6 +1191,7 @@ function _toggleLine(cm, name, liststyle) {
         'quote': /^(\s*)>\s+/,
         'unordered-list': listRegexp,
         'ordered-list': listRegexp,
+        'check-list': /^(\s*)(- \[[ xX]])(\s+)/,
     };
 
     var _getChar = function (name, i) {
@@ -1191,6 +1199,7 @@ function _toggleLine(cm, name, liststyle) {
             'quote': '>',
             'unordered-list': liststyle,
             'ordered-list': '%%i.',
+            'check-list': '- [ ]',
         };
 
         return map[name].replace('%%i', i);
@@ -1199,8 +1208,9 @@ function _toggleLine(cm, name, liststyle) {
     var _checkChar = function (name, char) {
         var map = {
             'quote': '>',
-            'unordered-list': '\\' + liststyle,
+            'unordered-list': '\\' + liststyle + '\\s(?!!\\[[ xX]])',
             'ordered-list': '\\d+.',
+            'check-list': '- \\[[ xX]]',
         };
         var rt = new RegExp(map[name]);
 
@@ -1222,18 +1232,18 @@ function _toggleLine(cm, name, liststyle) {
     };
 
     var line = 1;
+    var listTypes = ['unordered-list', 'ordered-list', 'check-list'];
+    var currentType = Object.keys(stat)[0];
     for (var i = startPoint.line; i <= endPoint.line; i++) {
         (function (i) {
             var text = cm.getLine(i);
             if (stat[name]) {
                 text = text.replace(repl[name], '$1');
+            } else if ( listTypes.includes(currentType) && listTypes.includes(name) ) {
+                text = text.replace(repl[currentType], '$1');
+                text = _toggle(name, text, false);
+                line += 1;
             } else {
-                // If we're toggling unordered-list formatting, check if the current line
-                // is part of an ordered-list, and if so, untoggle that first.
-                // Workaround for https://github.com/Ionaru/easy-markdown-editor/issues/92
-                if (name == 'unordered-list') {
-                    text = _toggle('ordered-list', text, true);
-                }
                 text = _toggle(name, text, false);
                 line += 1;
             }
@@ -1472,6 +1482,7 @@ var iconClassMap = {
     'quote': 'fa fa-quote-left',
     'ordered-list': 'fa fa-list-ol',
     'unordered-list': 'fa fa-list-ul',
+    'check-list': 'fa fa-check-square-o',
     'clean-block': 'fa fa-eraser',
     'link': 'fa fa-link',
     'image': 'fa fa-image',
@@ -1572,6 +1583,13 @@ var toolbarBuiltInButtons = {
         action: toggleOrderedList,
         className: iconClassMap['ordered-list'],
         title: 'Numbered List',
+        default: true,
+    },
+    'check-list': {
+        name: 'check-list',
+        action: toggleCheckList,
+        className: iconClassMap['check-list'],
+        title: 'Check List',
         default: true,
     },
     'clean-block': {
@@ -2897,6 +2915,7 @@ EasyMDE.toggleHeading6 = toggleHeading6;
 EasyMDE.toggleCodeBlock = toggleCodeBlock;
 EasyMDE.toggleUnorderedList = toggleUnorderedList;
 EasyMDE.toggleOrderedList = toggleOrderedList;
+EasyMDE.toggleCheckList = toggleCheckList;
 EasyMDE.cleanBlock = cleanBlock;
 EasyMDE.drawLink = drawLink;
 EasyMDE.drawImage = drawImage;
@@ -2956,6 +2975,9 @@ EasyMDE.prototype.toggleUnorderedList = function () {
 };
 EasyMDE.prototype.toggleOrderedList = function () {
     toggleOrderedList(this);
+};
+EasyMDE.prototype.toggleCheckList = function () {
+    toggleCheckList(this);
 };
 EasyMDE.prototype.cleanBlock = function () {
     cleanBlock(this);

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1208,7 +1208,7 @@ function _toggleLine(cm, name, liststyle) {
     var _checkChar = function (name, char) {
         var map = {
             'quote': '>',
-            'unordered-list': '\\' + liststyle + '\\s(?!!\\[[ xX]])',
+            'unordered-list': '\\' + liststyle,
             'ordered-list': '\\d+.',
             'check-list': '- \\[[ xX]]',
         };

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -1234,6 +1234,16 @@ function _toggleLine(cm, name, liststyle) {
     var line = 1;
     var listTypes = ['unordered-list', 'ordered-list', 'check-list'];
     var currentType = Object.keys(stat)[0];
+    // After selectAll the cursor's start sits at column 0, where getTokenAt
+    // yields no type — stat comes back empty and currentType is undefined,
+    // making the swap branch below unreachable. Fall back to detecting the
+    // type from the first selected line's text.
+    if (!listTypes.includes(currentType)) {
+        var firstLineText = cm.getLine(startPoint.line);
+        if (/^\s*- \[[ xX]]\s/.test(firstLineText)) currentType = 'check-list';
+        else if (/^\s*\d+\.\s/.test(firstLineText)) currentType = 'ordered-list';
+        else if (/^\s*[*\-+]\s/.test(firstLineText)) currentType = 'unordered-list';
+    }
     for (var i = startPoint.line; i <= endPoint.line; i++) {
         (function (i) {
             var text = cm.getLine(i);

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -33,6 +33,7 @@ type ToolbarButton =
     | 'quote'
     | 'unordered-list'
     | 'ordered-list'
+    | 'check-list'
     | 'link'
     | 'image'
     | 'upload-image'
@@ -277,6 +278,7 @@ declare class EasyMDE {
     static toggleBlockquote: (editor: EasyMDE) => void;
     static toggleUnorderedList: (editor: EasyMDE) => void;
     static toggleOrderedList: (editor: EasyMDE) => void;
+    static toggleCheckList: (editor: EasyMDE) => void;
     static cleanBlock: (editor: EasyMDE) => void;
     static drawLink: (editor: EasyMDE) => void;
     static drawImage: (editor: EasyMDE) => void;


### PR DESCRIPTION
1. add check-list toggle & icon
2. can switch between check-list/unordered-list/ordered-list now
3. fix bug: switch bwtween ul/ol will add extra spaces before marker and content