### PR TITLE
Add YAML/TOML frontmatter processing (closes #633)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
+
+## Project Overview
+
+EasyMDE is a browser-based, embeddable JavaScript Markdown editor — a drop-in `<textarea>` replacement with a rich toolbar, live preview, autosave, spell checking, and image upload. It is published to npm as the `easymde` package.
+
+**Core dependencies**: CodeMirror 5 (editing), Marked 4 (preview rendering), Font Awesome (icons, loaded externally), codemirror-spell-checker.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm install` | Install dependencies and auto-runs `gulp` (prepare script) |
+| `npm test` | Full test suite: lint + type check + E2E |
+| `npm run lint` | ESLint on `src/js/**/*.js` (via gulp) |
+| `npm run e2e` | Build + lint Cypress tests + run Cypress headlessly |
+| `npm run cypress:run` | Run Cypress E2E tests headlessly |
+| `npm run test:types` | TypeScript type checking (`tsc --project types/tsconfig.json`) |
+| `gulp` | Full build: lint → bundle JS → minify CSS → output to `dist/` |
+| `gulp watch` | Watch mode for JS and CSS changes |
+
+## Build System
+
+**Gulp + Browserify + Terser** — no webpack, vite, babel, or Jest.
+
+- `gulpfile.js` defines the entire build pipeline.
+- JS: Browserify bundles `src/js/easymde.js` as UMD (`standalone: 'EasyMDE'`), then Terser minifies → `dist/easymde.min.js`.
+- CSS: Concatenates CodeMirror CSS + EasyMDE CSS + spell-checker CSS, minifies → `dist/easymde.min.css`.
+
+## Architecture
+
+### Source Layout
+
+```
+src/
+  js/
+    easymde.js              # ENTIRE application (~3300 lines, single file)
+    codemirror/
+      tablist.js            # Custom CodeMirror command for tab indentation in lists
+  css/
+    easymde.css             # All editor styles (~425 lines)
+types/
+  easymde.d.ts              # TypeScript type definitions (~300 lines)
+  easymde-test.ts           # Type usage test file (~239 lines)
+cypress/
+  e2e/                      # 7 E2E test suites
+```
+
+### Key Architectural Points
+
+- **Single-file application**: All application logic lives in `src/js/easymde.js`. There is no module-based architecture — it uses CommonJS (`require()`) and is bundled with Browserify.
+- **Constructor + prototype pattern**: `function EasyMDE(options)` with prototype methods. Static methods on the `EasyMDE` constructor allow toolbar actions to be referenced by name (e.g., `EasyMDE.toggleBold`).
+- **Toolbar system**: Dynamically creates buttons, dropdowns, separators. Supports custom buttons and actions. Toolbar items reference editor actions by function name (string) or direct function.
+- **Preview system**: Renders Markdown via Marked, supports sync scrolling and side-by-side mode.
+- **Image upload**: Drag-and-drop, paste, file browse. Supports custom upload functions and server endpoints.
+- **Autosave**: localStorage-based with configurable delay.
+- **Keyboard shortcuts**: Fully customizable, cross-platform (Cmd vs Ctrl auto-conversion via `fixShortcut()`).
+- **Frontmatter processing** (opt-in via `enableFrontmatter: true`): Detects `---`/`+++` delimited YAML blocks at the top of documents. Renders them as key-value tables in preview, applies `cm-frontmatter` CSS class in the editor, blocks formatting actions inside frontmatter, and excludes frontmatter from word/line counts. Use `previewIgnoreFrontmatter: true` to suppress the table rendering in preview while keeping all other frontmatter behavior.
+
+### Code Structure Within `easymde.js`
+
+| Lines | Section |
+|-------|---------|
+| 1–15 | Imports (CodeMirror, spell-checker, marked) |
+| 17–50 | Global state/constants (platform detection, key bindings, shortcuts) |
+| 52–1480 | Utility functions (toolbar DOM, editor actions, toggle helpers, selection replacement, frontmatter helpers) |
+| 1762 | `EasyMDE` constructor |
+| 1985–3050 | Prototype methods (image upload, status bar, rendering, lifecycle, toolbar/statusbar creation, value access, state queries) |
+
+### Frontmatter Implementation
+
+See [`docs/frontmatter.md`](docs/frontmatter.md) for complete documentation of the frontmatter feature, including options, detection rules, preview rendering, editor styling, formatting guards, status bar behavior, YAML syntax support, API reference, and test coverage.
+
+Key files:
+
+| File | Purpose |
+|------|---------|
+| `src/js/easymde.js` | All frontmatter logic (helpers, markdown(), render(), createStatusbar(), guarded actions) |
+| `src/css/easymde.css` | `.cm-frontmatter` and GFM override rules (bottom of file) |
+| `types/easymde.d.ts` | `enableFrontmatter?` and `previewIgnoreFrontmatter?` option types |
+| `cypress/e2e/7-frontmatter/` | 14 E2E tests for frontmatter |
+
+## Testing
+
+- **Cypress** for E2E tests (7 suites in `cypress/e2e/`, 61 total tests).
+- **TypeScript** type checking validates `types/easymde.d.ts` against `types/easymde-test.ts`.
+- CI runs on Node.js 14–24 matrix via GitHub Actions (`.github/workflows/cd.yaml`).
+
+## Code Style
+
+- ESLint config in `.eslintrc`: single quotes, semicolons required, trailing commas, ES2018, extends `eslint:recommended`.
+- `.editorconfig`: UTF-8, LF line endings, 4-space indent (2-space for YAML).

--- a/cypress/e2e/7-frontmatter/frontmatter.cy.js
+++ b/cypress/e2e/7-frontmatter/frontmatter.cy.js
@@ -1,0 +1,255 @@
+/// <reference types="cypress" />
+
+describe('Frontmatter', () => {
+    beforeEach(() => {
+        cy.visit(__dirname + '/index.html');
+    });
+
+    it('handles simple frontmatter with single key', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').then(function(el) {
+            var cm = el[0].CodeMirror;
+            cm.setValue('---\nfrontmatter: testing\n---\n\nBody text');
+        });
+
+        cy.previewOn();
+
+        cy.get('.EasyMDEContainer .editor-preview table').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('frontmatter').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('testing').should('exist');
+        // The frontmatter content should NOT be rendered as a heading
+        cy.get('.EasyMDEContainer .editor-preview h2').should('not.exist');
+        // Body text should render normally
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p>Body text</p>');
+    });
+
+    it('does not apply heading styling to frontmatter content in the editor', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').then(function(el) {
+            var cm = el[0].CodeMirror;
+            cm.setValue('---\nfrontmatter: testing\n---\n\n# Real Heading');
+        });
+
+        // The frontmatter lines should have the cm-frontmatter class
+        cy.get('.EasyMDEContainer .CodeMirror .cm-frontmatter').should('have.length', 3);
+        // The body heading should still work normally
+        cy.get('.EasyMDEContainer .CodeMirror .cm-header').should('exist');
+        // Frontmatter lines should NOT have heading-sized text visually
+        // (our CSS overrides .cm-header inside .cm-frontmatter to inherit font-size)
+        cy.get('.EasyMDEContainer .CodeMirror .cm-frontmatter').first().then(function($el) {
+            var fontSize = $el.css('font-size');
+            // The frontmatter line font size should match normal text, not heading
+            expect(parseFloat(fontSize)).to.be.lessThan(18);
+        });
+    });
+
+    it('renders frontmatter as a table in preview', () => {
+        cy.get('.EasyMDEContainer').should('be.visible');
+
+        // Set value directly to avoid Cypress typing issues with CodeMirror
+        cy.get('.EasyMDEContainer .CodeMirror').then(function(el) {
+            var cm = el[0].CodeMirror;
+            cm.setValue('---\ntitle: My Document\nauthor: John Doe\n---\n\n# Hello World');
+        });
+
+        cy.previewOn();
+
+        // Check table exists with correct cells
+        cy.get('.EasyMDEContainer .editor-preview table').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('title').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('My Document').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('author').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('John Doe').should('exist');
+
+        // Body content should also render
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<h1');
+    });
+
+    it('does not show --- delimiters in the preview table', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: Test');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Some text');
+
+        cy.previewOn();
+
+        // The --- should not appear in the preview HTML
+        cy.get('.EasyMDEContainer .editor-preview').should('not.contain.html', '<code>---</code>');
+        cy.get('.EasyMDEContainer .editor-preview table').should('exist');
+    });
+
+    it('ignores comment lines starting with #', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').then(function(el) {
+            var cm = el[0].CodeMirror;
+            cm.setValue('---\ntitle: My Doc\n# This is a comment\nauthor: Jane\n---\n\nBody text');
+        });
+
+        cy.previewOn();
+
+        // Table should exist with the valid keys
+        cy.get('.EasyMDEContainer .editor-preview table').should('exist');
+        // Valid keys should appear
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('title').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('author').should('exist');
+        // Comment text should not appear as a row
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('This is a comment').should('not.exist');
+    });
+
+    it('handles multi-line values with | indicator', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('description: |');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('First line');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Second line');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body');
+
+        cy.previewOn();
+
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('description').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table').should('contain', 'First line');
+        cy.get('.EasyMDEContainer .editor-preview table').should('contain', 'Second line');
+        // Verify the table has exactly one row (the description multi-line value)
+        cy.get('.EasyMDEContainer .editor-preview table tr').should('have.length', 1);
+    });
+
+    it('handles indented keys with &nbsp;', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: Test');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('  child: value1');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body');
+
+        cy.previewOn();
+
+        cy.get('.EasyMDEContainer .editor-preview table').should('contain.html', '&nbsp;&nbsp;child');
+    });
+
+    it('ignores lines without key:value pattern', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: Test');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('just some random text');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body');
+
+        cy.previewOn();
+
+        // Only title row should exist, not the random text
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('title').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('just some random text').should('not.exist');
+    });
+
+    it('excludes frontmatter from word count', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: My Document Title');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Hello world');
+
+        // Word count should be 2 (Hello world), not counting frontmatter
+        cy.get('.EasyMDEContainer .editor-statusbar .words').should('contain', '2');
+    });
+
+    it('excludes frontmatter from line count', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: Test');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Line one');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Line two');
+
+        // Line count should be 2 (Line one, Line two), not counting frontmatter (3 lines)
+        cy.get('.EasyMDEContainer .editor-statusbar .lines').should('contain', '2');
+    });
+
+    it('blocks formatting in frontmatter', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: Test');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body text');
+
+        // Move cursor to frontmatter line (line 2 = the "title: Test" line)
+        cy.get('.EasyMDEContainer .CodeMirror').type('{upArrow}{upArrow}{upArrow}{upArrow}');
+
+        // Try to click bold
+        cy.get('.EasyMDEContainer .editor-toolbar button.bold').click();
+
+        // The frontmatter line should not have ** around it
+        cy.get('.EasyMDEContainer .CodeMirror-line').contains('title: Test').should('exist');
+    });
+
+    it('supports +++ delimiter variant', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('+++');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: TOML Style');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('+++');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body');
+
+        cy.previewOn();
+
+        cy.get('.EasyMDEContainer .editor-preview table').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('title').should('exist');
+        cy.get('.EasyMDEContainer .editor-preview table td').contains('TOML Style').should('exist');
+    });
+
+    it('does not detect frontmatter without closing delimiter', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: No Close');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        // No closing ---, just body text
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body text');
+
+        cy.previewOn();
+
+        // Without closing delimiter, frontmatter should NOT be detected
+        cy.get('.EasyMDEContainer .editor-preview table').should('not.exist');
+        // The content should render as normal markdown
+        cy.get('.EasyMDEContainer .editor-preview').should('contain.html', '<p>');
+    });
+
+    it('applies cm-frontmatter CSS class to frontmatter lines', () => {
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('title: Test');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('---');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('{enter}');
+        cy.get('.EasyMDEContainer .CodeMirror').type('Body');
+
+        // Check that frontmatter lines have the cm-frontmatter class
+        cy.get('.EasyMDEContainer .CodeMirror .cm-frontmatter').should('exist');
+    });
+});

--- a/cypress/e2e/7-frontmatter/index.html
+++ b/cypress/e2e/7-frontmatter/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frontmatter</title>
+    <link rel="stylesheet" href="../../../dist/easymde.min.css">
+    <script src="../../../dist/easymde.min.js"></script>
+</head>
+<body>
+    <textarea id="textarea"></textarea>
+    <script>
+        const easyMDE = new EasyMDE({
+            enableFrontmatter: true
+        });
+    </script>
+</body>
+</html>

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -1,0 +1,355 @@
+# Frontmatter Processing
+
+EasyMDE supports optional YAML/TOML frontmatter detection and rendering. When enabled, frontmatter blocks at the top of a document are rendered as key-value tables in the preview, visually distinguished in the editor, excluded from formatting actions, and excluded from word/line counts.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Options](#options)
+- [Frontmatter Detection](#frontmatter-detection)
+- [Preview Rendering](#preview-rendering)
+- [Editor Styling](#editor-styling)
+- [Formatting Guard](#formatting-guard)
+- [Status Bar](#status-bar)
+- [YAML Syntax Support](#yaml-syntax-support)
+- [API Reference](#api-reference)
+- [Testing](#testing)
+
+---
+
+## Overview
+
+Frontmatter is a metadata block at the top of a Markdown document, commonly used by static site generators (Jekyll, Hugo, etc.). EasyMDE supports both YAML (`---`) and TOML (`+++`) delimiters.
+
+**Example document with frontmatter:**
+
+```markdown
+---
+title: My Document
+author: Jane Doe
+description: |
+  This is a multi-line
+  description value.
+# This is a comment
+---
+
+# Heading
+
+Body text here.
+```
+
+**In the editor:** The three `---` delimiter lines and the metadata lines between them are styled in gray italic text with GFM heading/hr formatting suppressed.
+
+**In the preview:** The frontmatter is rendered as an HTML `<table>` above the body content. Delimiter lines and comment lines are excluded from the table.
+
+---
+
+## Options
+
+Frontmatter processing is controlled by two options in the `EasyMDE.Options` configuration:
+
+### `enableFrontmatter`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `false` |
+| **Required** | Yes (set to `true` to activate frontmatter processing) |
+
+Enables frontmatter detection, rendering, editor styling, formatting exclusion, and status bar adjustments.
+
+```js
+const editor = new EasyMDE({
+    enableFrontmatter: true
+});
+```
+
+### `previewIgnoreFrontmatter`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `false` |
+| **Required** | No |
+
+When `true`, the frontmatter block is still detected and stripped from the body text (so it doesn't leak into the markdown rendering), but the key-value `<table>` is **not** rendered in the preview. All other frontmatter behavior (editor styling, formatting guard, status bar exclusion) remains active.
+
+This option has no effect when `enableFrontmatter` is `false`.
+
+```js
+const editor = new EasyMDE({
+    enableFrontmatter: true,
+    previewIgnoreFrontmatter: true
+});
+```
+
+---
+
+## Frontmatter Detection
+
+Detection is handled by `findFrontmatterEnd(text)`, which returns the line index after the closing delimiter, or `-1` if no valid frontmatter block exists.
+
+**Rules:**
+
+1. The first line of the document must be exactly `---` or `+++` (whitespace-trimmed).
+2. A matching closing delimiter must appear later in the document. Without one, no frontmatter is detected.
+3. The delimiter type must match: `---` opens and closes with `---`; `+++` opens and closes with `+++`.
+
+```js
+// Returns the line index after the closing delimiter (0-indexed)
+findFrontmatterEnd('---\ntitle: Hello\n---\n\nBody text'); // Returns 3
+findFrontmatterEnd('---\ntitle: Hello\n\nBody text');       // Returns -1 (no closing ---)
+findFrontmatterEnd('# Heading\n\nBody text');               // Returns -1 (no opening ---)
+```
+
+---
+
+## Preview Rendering
+
+When frontmatter is enabled and `previewIgnoreFrontmatter` is `false`, the `markdown()` method in `EasyMDE.prototype.markdown()` processes frontmatter before passing text to `marked.parse()`:
+
+1. **Detect** the frontmatter block via `findFrontmatterEnd()`.
+2. **Render** the frontmatter as an HTML `<table>` via `renderFrontmatterTable()`.
+3. **Strip** the frontmatter lines from the text passed to `marked.parse()`.
+4. **Prepend** the table HTML to the rendered markdown output.
+
+The resulting preview HTML structure:
+
+```html
+<table>
+    <tr><td>title</td><td>My Document</td></tr>
+    <tr><td>author</td><td>Jane Doe</td></tr>
+</table>
+<h1>Heading</h1>
+<p>Body text here.</p>
+```
+
+---
+
+## Editor Styling
+
+When `enableFrontmatter` is enabled, frontmatter lines receive the `cm-frontmatter` CSS class via CodeMirror's `addLineClass()` method. This is managed by `EasyMDE.prototype.updateFrontmatterLineClasses()`.
+
+The class is applied to every line from line 0 through the closing delimiter line (exclusive of the body content). It is re-applied on every `change` event and after initial render.
+
+**CSS rules (`src/css/easymde.css`):**
+
+```css
+/* Frontmatter line styling */
+.cm-frontmatter {
+    color: #777;
+    font-style: italic;
+}
+
+/* Suppress GFM heading/hr styling inside frontmatter lines */
+.cm-frontmatter .cm-header {
+    font-size: inherit;
+    font-weight: normal;
+    color: inherit;
+}
+.cm-frontmatter .cm-hr {
+    color: inherit;
+    font-weight: normal;
+}
+.cm-frontmatter .cm-formatting {
+    color: inherit;
+    font-weight: normal;
+}
+```
+
+The `.cm-header` override prevents CodeMirror's GFM mode from rendering frontmatter content (e.g., `# comment` or text before `---`) as large headings. The `.cm-hr` and `.cm-formatting` overrides prevent horizontal rule and formatting token styling from activating within frontmatter.
+
+---
+
+## Formatting Guard
+
+All formatting action functions guard against cursor positions inside frontmatter. The guard checks whether the cursor's starting line falls within the frontmatter block:
+
+```js
+if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
+```
+
+**Guarded functions (21 total):**
+
+| Function | Purpose |
+|----------|---------|
+| `toggleBold` | Bold formatting |
+| `toggleItalic` | Italic formatting |
+| `toggleStrikethrough` | Strikethrough formatting |
+| `toggleCodeBlock` | Code block formatting |
+| `toggleBlockquote` | Blockquote formatting |
+| `toggleHeadingSmaller` | Decrease heading level |
+| `toggleHeadingBigger` | Increase heading level |
+| `toggleHeading1`–`toggleHeading6` | Set heading level 1–6 |
+| `toggleUnorderedList` | Unordered list |
+| `toggleOrderedList` | Ordered list |
+| `toggleCheckList` | Checklist |
+| `cleanBlock` | Clean block formatting |
+| `drawLink` | Insert link |
+| `drawImage` | Insert image |
+| `drawTable` | Insert table |
+| `drawHorizontalRule` | Insert horizontal rule |
+
+When the cursor is on a frontmatter line, these functions return immediately without modifying the document.
+
+---
+
+## Status Bar
+
+When `enableFrontmatter` is enabled, the status bar's word and line counts exclude frontmatter lines:
+
+- **Word count:** Frontmatter lines are stripped from the text before `wordCount()` is called.
+- **Line count:** `fmEnd` (the number of frontmatter lines) is subtracted from `cm.lineCount()`.
+
+This applies to both the initial value and the `onUpdate` handler, so counts stay accurate as the user types.
+
+---
+
+## YAML Syntax Support
+
+`renderFrontmatterTable()` parses frontmatter lines into a 2-column `<table>` (key / value). It supports:
+
+### Standard key-value pairs
+
+Lines matching the pattern `key: value` are rendered as table rows:
+
+```yaml
+title: My Document
+author: Jane Doe
+```
+
+Renders as:
+
+| Key | Value |
+|-----|-------|
+| title | My Document |
+| author | Jane Doe |
+
+### Comments
+
+Lines where `#` is the first non-whitespace character are treated as comments and excluded from the table:
+
+```yaml
+# This is a comment
+title: My Doc
+```
+
+Only `title: My Doc` appears in the rendered table.
+
+### Multi-line values
+
+A value of `|` (literal block scalar) or `>` (folded block scalar) indicates a multi-line value. Subsequent non-blank lines are collected until a blank line or the closing delimiter:
+
+```yaml
+description: |
+  First line
+  Second line
+```
+
+Renders as a single table row with the value `First line<br>Second line`.
+
+### Indented keys
+
+Leading whitespace on a key is converted to `&nbsp;` characters (2 per indent level) in the rendered table:
+
+```yaml
+title: Test
+  child: value1
+```
+
+The `child` key renders as `&nbsp;&nbsp;child` in the table.
+
+### Non-matching lines
+
+Lines that don't match the `key: value` pattern and aren't comments are silently ignored (not rendered in the table).
+
+---
+
+## API Reference
+
+### `findFrontmatterEnd(text)`
+
+Returns the line index after the closing frontmatter delimiter, or `-1` if no valid frontmatter block is found.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | `string` | Full document text |
+
+**Returns:** `number` — Line index after closing delimiter, or `-1`.
+
+---
+
+### `renderFrontmatterTable(text)`
+
+Parses frontmatter lines and returns an HTML `<table>` string. Returns empty string if no frontmatter is found or no valid key-value pairs exist.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | `string` | Full document text |
+
+**Returns:** `string` — HTML table markup, or `''`.
+
+---
+
+### `isLineInFrontmatter(cm, line)`
+
+Checks whether a given 0-indexed line number falls within the frontmatter block.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cm` | `CodeMirror.Editor` | The CodeMirror instance |
+| `line` | `number` | 0-indexed line number |
+
+**Returns:** `boolean` — `true` if the line is inside the frontmatter block.
+
+---
+
+### `EasyMDE.prototype.updateFrontmatterLineClasses()`
+
+Clears `cm-frontmatter` from all lines, then re-applies it to frontmatter lines. Called automatically on `change` events and after initial render.
+
+**Parameters:** None.
+
+---
+
+### `escapeHtml(s)`
+
+Escapes `&`, `<`, `>`, and `"` characters to their HTML entity equivalents. Used internally by `renderFrontmatterTable()`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `string` | Raw string |
+
+**Returns:** `string` — HTML-escaped string.
+
+---
+
+## Testing
+
+Frontmatter is tested by a dedicated Cypress E2E test suite in `cypress/e2e/7-frontmatter/`. The suite contains 14 test cases:
+
+| # | Test | What it verifies |
+|---|------|-----------------|
+| 1 | Simple frontmatter with single key | Table renders with correct cells; no spurious heading; body text renders |
+| 2 | No heading styling in editor | `.cm-frontmatter` class applied; `.cm-header` still works for real headings; font size is normal |
+| 3 | Frontmatter rendered as table | Multiple key-value pairs render correctly; body content also renders |
+| 4 | Delimiters not shown in preview | `---` lines don't appear as `<code>---</code>` in preview HTML |
+| 5 | Comment lines ignored | Lines starting with `#` are excluded from the table |
+| 6 | Multi-line values with `\|` indicator | Block scalar `\|` collects multiple lines into one table row |
+| 7 | Indented keys with `&nbsp;` | Indented keys produce `&nbsp;&nbsp;` in rendered HTML |
+| 8 | Non-key:value lines ignored | Random text without a colon is not rendered as a table row |
+| 9 | Word count excludes frontmatter | Word count reflects only body text |
+| 10 | Line count excludes frontmatter | Line count reflects only body lines |
+| 11 | Formatting blocked in frontmatter | Bold button has no effect when cursor is on a frontmatter line |
+| 12 | `+++` TOML delimiter variant | `+++` works identically to `---` |
+| 13 | No closing delimiter | Without closing `---`, no table is rendered; content renders as normal markdown |
+| 14 | CSS class applied | `.cm-frontmatter` elements exist after typing frontmatter |
+
+**Test page:** `cypress/e2e/7-frontmatter/index.html` — Creates an editor instance with `enableFrontmatter: true`.
+
+**Run tests:**
+
+```bash
+npm run e2e          # Full suite (build + lint + all 61 tests)
+npm run cypress:run  # Cypress only (requires prior build)
+```

--- a/src/css/easymde.css
+++ b/src/css/easymde.css
@@ -401,3 +401,24 @@ span[data-img-src]::after {
     width: var(--width);
     background-repeat: no-repeat;
 }
+
+/* Frontmatter line styling (opt-in via enableFrontmatter option) */
+.cm-frontmatter {
+    color: #777;
+    font-style: italic;
+}
+
+/* Suppress GFM heading/hr styling inside frontmatter lines */
+.cm-frontmatter .cm-header {
+    font-size: inherit;
+    font-weight: normal;
+    color: inherit;
+}
+.cm-frontmatter .cm-hr {
+    color: inherit;
+    font-weight: normal;
+}
+.cm-frontmatter .cm-formatting {
+    color: inherit;
+    font-weight: normal;
+}

--- a/src/js/easymde.js
+++ b/src/js/easymde.js
@@ -421,6 +421,7 @@ function toggleFullScreen(editor) {
  * @param {EasyMDE} editor
  */
 function toggleBold(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleBlock(editor, 'bold', editor.options.blockStyles.bold);
 }
 
@@ -430,6 +431,7 @@ function toggleBold(editor) {
  * @param {EasyMDE} editor
  */
 function toggleItalic(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleBlock(editor, 'italic', editor.options.blockStyles.italic);
 }
 
@@ -439,6 +441,7 @@ function toggleItalic(editor) {
  * @param {EasyMDE} editor
  */
 function toggleStrikethrough(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleBlock(editor, 'strikethrough', '~~');
 }
 
@@ -447,6 +450,7 @@ function toggleStrikethrough(editor) {
  * @param {EasyMDE} editor
  */
 function toggleCodeBlock(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     var fenceCharsToInsert = editor.options.blockStyles.code;
 
     function fencing_line(line) {
@@ -733,6 +737,7 @@ function toggleCodeBlock(editor) {
  * Action for toggling blockquote.
  */
 function toggleBlockquote(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleLine(editor.codemirror, 'quote');
 }
 
@@ -740,6 +745,7 @@ function toggleBlockquote(editor) {
  * Action for toggling heading size: normal -> h1 -> h2 -> h3 -> h4 -> h5 -> h6 -> normal
  */
 function toggleHeadingSmaller(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, 'smaller');
 }
 
@@ -747,6 +753,7 @@ function toggleHeadingSmaller(editor) {
  * Action for toggling heading size: normal -> h6 -> h5 -> h4 -> h3 -> h2 -> h1 -> normal
  */
 function toggleHeadingBigger(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, 'bigger');
 }
 
@@ -754,6 +761,7 @@ function toggleHeadingBigger(editor) {
  * Action for toggling heading size 1
  */
 function toggleHeading1(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, undefined, 1);
 }
 
@@ -761,6 +769,7 @@ function toggleHeading1(editor) {
  * Action for toggling heading size 2
  */
 function toggleHeading2(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, undefined, 2);
 }
 
@@ -768,6 +777,7 @@ function toggleHeading2(editor) {
  * Action for toggling heading size 3
  */
 function toggleHeading3(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, undefined, 3);
 }
 
@@ -775,6 +785,7 @@ function toggleHeading3(editor) {
  * Action for toggling heading size 4
  */
 function toggleHeading4(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, undefined, 4);
 }
 
@@ -782,6 +793,7 @@ function toggleHeading4(editor) {
  * Action for toggling heading size 5
  */
 function toggleHeading5(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, undefined, 5);
 }
 
@@ -789,6 +801,7 @@ function toggleHeading5(editor) {
  * Action for toggling heading size 6
  */
 function toggleHeading6(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleHeading(editor.codemirror, undefined, 6);
 }
 
@@ -797,6 +810,7 @@ function toggleHeading6(editor) {
  * Action for toggling ul.
  */
 function toggleUnorderedList(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     var cm = editor.codemirror;
 
     var listStyle = '*'; // Default
@@ -812,10 +826,12 @@ function toggleUnorderedList(editor) {
  * Action for toggling ol.
  */
 function toggleOrderedList(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleLine(editor.codemirror, 'ordered-list');
 }
 
 function toggleCheckList(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _toggleLine(editor.codemirror, 'check-list');
 }
 
@@ -823,6 +839,7 @@ function toggleCheckList(editor) {
  * Action for clean block (remove headline, list, blockquote code, markers)
  */
 function cleanBlock(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     _cleanBlock(editor.codemirror);
 }
 
@@ -831,6 +848,7 @@ function cleanBlock(editor) {
  * @param {EasyMDE} editor
  */
 function drawLink(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     var options = editor.options;
     var url = 'https://';
     if (options.promptURLs) {
@@ -848,6 +866,7 @@ function drawLink(editor) {
  * @param {EasyMDE} editor
  */
 function drawImage(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     var options = editor.options;
     var url = 'https://';
     if (options.promptURLs) {
@@ -910,6 +929,7 @@ function afterImageUploaded(editor, url) {
  * @param {EasyMDE} editor
  */
 function drawTable(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     var cm = editor.codemirror;
     var stat = getState(cm);
     var options = editor.options;
@@ -921,6 +941,7 @@ function drawTable(editor) {
  * @param {EasyMDE} editor
  */
 function drawHorizontalRule(editor) {
+    if (editor.codemirror && isLineInFrontmatter(editor.codemirror, editor.codemirror.getCursor('start').line)) return;
     var cm = editor.codemirror;
     var stat = getState(cm);
     var options = editor.options;
@@ -1479,6 +1500,110 @@ function wordCount(data) {
     return count;
 }
 
+/**
+ * Detect the end of a YAML frontmatter block.
+ * Returns the line index (0-based) after the closing delimiter,
+ * or -1 if no frontmatter block is found.
+ * @param {string} text - The full document text.
+ * @return {number} The index of the first line after the frontmatter block, or -1.
+ */
+function findFrontmatterEnd(text) {
+    if (!text) return -1;
+    var lines = text.split('\n');
+    if (lines.length === 0) return -1;
+
+    var first = lines[0].trim();
+    if (first !== '---' && first !== '+++') return -1;
+
+    var delimiter = first;
+    for (var i = 1; i < lines.length; i++) {
+        if (lines[i].trim() === delimiter) {
+            return i + 1;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ * @param {string} s - The string to escape.
+ * @return {string} The escaped string.
+ */
+function escapeHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/**
+ * Render a frontmatter block as an HTML table.
+ * @param {string} text - The full document text.
+ * @return {string} HTML table string, or empty string if no frontmatter.
+ */
+function renderFrontmatterTable(text) {
+    var endLine = findFrontmatterEnd(text);
+    if (endLine <= 0) return '';
+
+    var lines = text.split('\n');
+    var fmLines = lines.slice(1, endLine - 1);
+
+    var rows = '';
+    var i = 0;
+    while (i < fmLines.length) {
+        var line = fmLines[i];
+
+        // Comment: first non-whitespace char is #
+        if (/^\s*#/.test(line)) { i++; continue; }
+
+        // Multi-line value indicator: | or > as first char of value
+        var mlMatch = line.match(/^\s*([^#\s][^:]*?)\s*:\s*([|>])\s*$/);
+        if (mlMatch) {
+            var mlKey = mlMatch[1];
+            var indent = line.match(/^(\s*)/)[1].length;
+            var spacer = '';
+            for (var s = 0; s < indent * 2; s++) { spacer += '&nbsp;'; }
+            var valueLines = [];
+            i++;
+            while (i < fmLines.length) {
+                var next = fmLines[i];
+                if (next.trim() === lines[0].trim()) break;
+                if (next.trim() === '') break;
+                valueLines.push(escapeHtml(next));
+                i++;
+            }
+            var mlValue = valueLines.join('<br>');
+            rows += '<tr><td>' + spacer + escapeHtml(mlKey.trim()) + '</td><td>' + mlValue + '</td></tr>';
+            continue;
+        }
+
+        // Standard key: value line
+        var m = line.match(/^\s*([^#\s][^:]*?)\s*:\s*(.*)$/);
+        if (m) {
+            var key = m[1];
+            var value = m[2];
+            var keyIndent = line.match(/^(\s*)/)[1].length;
+            var keySpacer = '';
+            for (var ks = 0; ks < keyIndent * 2; ks++) { keySpacer += '&nbsp;'; }
+            rows += '<tr><td>' + keySpacer + escapeHtml(key.trim()) + '</td><td>' + escapeHtml(value) + '</td></tr>';
+        }
+        i++;
+    }
+
+    if (rows === '') return '';
+    return '<table>' + rows + '</table>';
+}
+
+/**
+ * Check if a given line is inside the frontmatter block.
+ * @param {CodeMirror} cm - The CodeMirror instance.
+ * @param {number} line - The 0-indexed line number.
+ * @return {boolean} True if the line is within the frontmatter block.
+ */
+function isLineInFrontmatter(cm, line) {
+    var text = cm.getValue();
+    var endLine = findFrontmatterEnd(text);
+    if (endLine <= 0) return false;
+    return line < endLine;
+}
+
 var iconClassMap = {
     'bold': 'fa fa-bold',
     'italic': 'fa fa-italic',
@@ -1890,6 +2015,10 @@ function EasyMDE(options) {
         alert(errorMessage);
     };
 
+    // Frontmatter processing options
+    options.enableFrontmatter = options.enableFrontmatter || false;
+    options.previewIgnoreFrontmatter = options.previewIgnoreFrontmatter || false;
+
     // Import-image default configuration
     options.uploadImage = options.uploadImage || false;
     options.imageMaxSize = options.imageMaxSize || 2097152; // 1024 * 1024 * 2
@@ -2076,8 +2205,26 @@ EasyMDE.prototype.markdown = function (text) {
         // Set options
         marked.use(markedOptions);
 
+        // Process frontmatter: optionally render as table and/or strip from markdown
+        var frontmatterHtml = '';
+        if (this.options.enableFrontmatter) {
+            var fmEnd = findFrontmatterEnd(text);
+            if (fmEnd > 0) {
+                if (!this.options.previewIgnoreFrontmatter) {
+                    frontmatterHtml = renderFrontmatterTable(text);
+                }
+                var bodyLines = text.split('\n').slice(fmEnd);
+                text = bodyLines.join('\n');
+            }
+        }
+
         // Convert the markdown to HTML
         var htmlText = marked.parse(text);
+
+        // Prepend frontmatter table HTML
+        if (frontmatterHtml) {
+            htmlText = frontmatterHtml + htmlText;
+        }
 
         // Sanitize HTML
         if (this.options.renderingConfig && typeof this.options.renderingConfig.sanitizerFunction === 'function') {
@@ -2091,6 +2238,30 @@ EasyMDE.prototype.markdown = function (text) {
         htmlText = removeListStyleWhenCheckbox(htmlText);
 
         return htmlText;
+    }
+};
+
+/**
+ * Update CodeMirror line classes for frontmatter lines.
+ * Adds 'cm-frontmatter' class to lines within the frontmatter block.
+ */
+EasyMDE.prototype.updateFrontmatterLineClasses = function () {
+    var cm = this.codemirror;
+    if (!cm) return;
+
+    var lineCount = cm.lineCount();
+    for (var i = 0; i < lineCount; i++) {
+        cm.removeLineClass(i, 'wrap', 'cm-frontmatter');
+    }
+
+    if (!this.options.enableFrontmatter) return;
+
+    var text = cm.getValue();
+    var endLine = findFrontmatterEnd(text);
+    if (endLine <= 0) return;
+
+    for (var j = 0; j < endLine; j++) {
+        cm.addLineClass(j, 'wrap', 'cm-frontmatter');
     }
 };
 
@@ -2320,6 +2491,10 @@ EasyMDE.prototype.render = function (el) {
         handleImages();
     });
 
+    this.codemirror.on('change', function () {
+        self.updateFrontmatterLineClasses();
+    });
+
     this.gui.sideBySide = this.createSideBySide();
     this._rendered = this.element;
 
@@ -2332,6 +2507,9 @@ EasyMDE.prototype.render = function (el) {
     setTimeout(function () {
         temp_cm.refresh();
     }.bind(temp_cm), 0);
+
+    // Apply frontmatter line classes after initial render
+    this.updateFrontmatterLineClasses();
 };
 
 EasyMDE.prototype.cleanup = function () {
@@ -2759,6 +2937,7 @@ EasyMDE.prototype.createStatusbar = function (status) {
     status = status || this.options.status;
     var options = this.options;
     var cm = this.codemirror;
+    var self = this;
 
     // Make sure the status variable is valid
     if (!status || status.length === 0) {
@@ -2789,17 +2968,41 @@ EasyMDE.prototype.createStatusbar = function (status) {
 
             if (name === 'words') {
                 defaultValue = function (el) {
-                    el.innerHTML = wordCount(cm.getValue());
+                    var text = cm.getValue();
+                    if (self.options.enableFrontmatter) {
+                        var fmEnd = findFrontmatterEnd(text);
+                        if (fmEnd > 0) {
+                            text = text.split('\n').slice(fmEnd).join('\n');
+                        }
+                    }
+                    el.innerHTML = wordCount(text);
                 };
                 onUpdate = function (el) {
-                    el.innerHTML = wordCount(cm.getValue());
+                    var text = cm.getValue();
+                    if (self.options.enableFrontmatter) {
+                        var fmEnd = findFrontmatterEnd(text);
+                        if (fmEnd > 0) {
+                            text = text.split('\n').slice(fmEnd).join('\n');
+                        }
+                    }
+                    el.innerHTML = wordCount(text);
                 };
             } else if (name === 'lines') {
                 defaultValue = function (el) {
-                    el.innerHTML = cm.lineCount();
+                    var count = cm.lineCount();
+                    if (self.options.enableFrontmatter) {
+                        var fmEnd = findFrontmatterEnd(cm.getValue());
+                        if (fmEnd > 0) count -= fmEnd;
+                    }
+                    el.innerHTML = count;
                 };
                 onUpdate = function (el) {
-                    el.innerHTML = cm.lineCount();
+                    var count = cm.lineCount();
+                    if (self.options.enableFrontmatter) {
+                        var fmEnd = findFrontmatterEnd(cm.getValue());
+                        if (fmEnd > 0) count -= fmEnd;
+                    }
+                    el.innerHTML = count;
                 };
             } else if (name === 'cursor') {
                 defaultValue = function (el) {

--- a/types/easymde.d.ts
+++ b/types/easymde.d.ts
@@ -237,6 +237,9 @@ declare namespace EasyMDE {
 
         overlayMode?: OverlayModeOptions;
 
+        enableFrontmatter?: boolean;
+        previewIgnoreFrontmatter?: boolean;
+
         direction?: 'ltr' | 'rtl';
     }
 }


### PR DESCRIPTION
- Add enableFrontmatter option for frontmatter detection and rendering
- Add previewIgnoreFrontmatter option to suppress table in preview
- Render frontmatter as key-value table in preview (--- and +++ delimiters)
- Apply cm-frontmatter CSS class with GFM heading/hr override in editor
- Block all 21 formatting actions when cursor is inside frontmatter
- Exclude frontmatter from word/line counts in status bar
- Support multi-line values (|/>), comments (#), and indented keys
- Add 14 E2E tests covering all frontmatter behaviors
- Add docs/frontmatter.md reference documentation
- Update CLAUDE.md with project docs and frontmatter pointers